### PR TITLE
Create location with slots + patient assignment

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -10,13 +10,13 @@ test: test-db
 
 check: detekt test
 
-test-db: stop-db
+test-db: stop-test-db stop-db
 	docker-compose -f docker-compose.test.yml up -d db
 
 stop-test-db:
 	docker-compose -f docker-compose.test.yml stop db
 
-db: stop-test-db
+db: stop-test-db stop-db
 	docker-compose -f ../docker-compose.yml up -d db
 
 stop-db:

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/model/Extensions.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/model/Extensions.kt
@@ -2,7 +2,7 @@ package blue.mild.covid.vaxx.dao.model
 
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.Table
-import java.util.UUID
+import java.util.*
 
 /**
  * Represents format for IDs.
@@ -33,3 +33,8 @@ fun Table.patientReference(name: String = "patient_id"): Column<EntityId> = enti
  * Reference to [Questions.id].
  */
 fun Table.questionReference(name: String = "question_id"): Column<EntityId> = entityId(name) references Questions.id
+
+/**
+ * Reference to [Locations.id].
+ */
+fun Table.locationReference(name: String = "location_id"): Column<EntityId> = entityId(name) references Locations.id

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/model/Extensions.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/model/Extensions.kt
@@ -2,7 +2,7 @@ package blue.mild.covid.vaxx.dao.model
 
 import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.Table
-import java.util.*
+import java.util.UUID
 
 /**
  * Represents format for IDs.

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/model/Locations.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/model/Locations.kt
@@ -4,7 +4,7 @@ object Locations : ManagedTable("locations") {
     /**
      * Address
      *
-     * We have other attributes zipCode & district to make matching with patient simpler
+     * We have other attributes zipCode & district to make matching with patient simpler.
      */
     val address = varchar("address", DatabaseTypeLength.DEFAULT_STRING)
 
@@ -19,7 +19,7 @@ object Locations : ManagedTable("locations") {
     val district = varchar("district", DatabaseTypeLength.SHORT_STRING)
 
     /**
-     * Validated phone number in format +420xxxyyyzzz
+     * Validated phone number in format +420xxxyyyzzz.
      */
     val phoneNumber = varchar("phone_number", DatabaseTypeLength.PHONE_NUMBER).nullable()
 
@@ -29,9 +29,7 @@ object Locations : ManagedTable("locations") {
     val email = varchar("email", DatabaseTypeLength.DEFAULT_STRING).nullable()
 
     /**
-     * Indication about patient - ie. chronic disease or teacher.
+     * Additional information about location.
      */
     val notes = text("notes").nullable()
-
-
 }

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/model/Locations.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/model/Locations.kt
@@ -1,7 +1,5 @@
 package blue.mild.covid.vaxx.dao.model
 
-import org.jetbrains.exposed.sql.`java-time`.timestamp
-
 object Locations : ManagedTable("locations") {
     /**
      * Address
@@ -33,7 +31,7 @@ object Locations : ManagedTable("locations") {
     /**
      * Indication about patient - ie. chronic disease or teacher.
      */
-    val note = varchar("note", DatabaseTypeLength.DEFAULT_STRING).nullable()
+    val notes = text("notes").nullable()
 
 
 }

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/model/Locations.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/model/Locations.kt
@@ -1,0 +1,39 @@
+package blue.mild.covid.vaxx.dao.model
+
+import org.jetbrains.exposed.sql.`java-time`.timestamp
+
+object Locations : ManagedTable("locations") {
+    /**
+     * Address
+     *
+     * We have other attributes zipCode & district to make matching with patient simpler
+     */
+    val address = varchar("address", DatabaseTypeLength.DEFAULT_STRING)
+
+    /**
+     * City zip code in form xxxyy.
+     */
+    val zipCode = integer("zip_code")
+
+    /**
+     * City district.
+     */
+    val district = varchar("district", DatabaseTypeLength.SHORT_STRING)
+
+    /**
+     * Validated phone number in format +420xxxyyyzzz
+     */
+    val phoneNumber = varchar("phone_number", DatabaseTypeLength.PHONE_NUMBER).nullable()
+
+    /**
+     * Validated email address.
+     */
+    val email = varchar("email", DatabaseTypeLength.DEFAULT_STRING).nullable()
+
+    /**
+     * Indication about patient - ie. chronic disease or teacher.
+     */
+    val note = varchar("note", DatabaseTypeLength.DEFAULT_STRING).nullable()
+
+
+}

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/model/VaccinationSlots.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/model/VaccinationSlots.kt
@@ -1,0 +1,30 @@
+package blue.mild.covid.vaxx.dao.model
+
+import org.jetbrains.exposed.sql.`java-time`.timestamp
+
+/**
+ * Available time slot for vaccination on the [Locations].
+ *
+ * Attribute patientId is null if that slot is available.
+ */
+object VaccinationSlots : ManagedTable("vaccination_slots") {
+
+    val locationId = locationReference()
+
+    /**
+     * Who was vaccinated.
+     */
+    val patientId = patientReference().nullable()
+
+    /**
+     * When time slot starts.
+     */
+    val from = timestamp("from")
+
+    /**
+     * When time slot ends.
+     */
+    val to = timestamp("to")
+
+
+}

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/model/VaccinationSlots.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/model/VaccinationSlots.kt
@@ -17,7 +17,7 @@ object VaccinationSlots : ManagedTable("vaccination_slots") {
     val patientId = patientReference().nullable()
 
     /**
-     * Identifier of the queue for locations with greater capacity
+     * Identifier of the queue for locations with greater capacity.
      */
     val queue = integer("queue")
 

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/model/VaccinationSlots.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/model/VaccinationSlots.kt
@@ -17,6 +17,11 @@ object VaccinationSlots : ManagedTable("vaccination_slots") {
     val patientId = patientReference().nullable()
 
     /**
+     * Identifier of the queue for locations with greater capacity
+     */
+    val queue = integer("queue")
+
+    /**
      * When time slot starts.
      */
     val from = timestamp("from")
@@ -25,6 +30,4 @@ object VaccinationSlots : ManagedTable("vaccination_slots") {
      * When time slot ends.
      */
     val to = timestamp("to")
-
-
 }

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/repository/LocationRepository.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/repository/LocationRepository.kt
@@ -114,6 +114,7 @@ class LocationRepository {
                 // MartinLlama - this is outer join, so slots are there only for some locations
                 // I want to have slots equal to empty list or null if there are no slots
                 // I have to hack it by using containsKey
+                // It believes that VaccinationSlots.id cannot be null, but when there are no slots it is null!
                 val slots = data.filter { it[VaccinationSlots.id] != null }.groupBy({ it[Locations.id] }, { it.mapSlots() })
                 data.distinctBy { it[Locations.id] }
                     .map { mapLocation(it, if (slots.containsKey(it[Locations.id])) slots.getValue(it[Locations.id]) else ArrayList()) }

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/repository/LocationRepository.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/repository/LocationRepository.kt
@@ -131,7 +131,7 @@ class LocationRepository {
     )
 
     private fun ResultRow.mapSlots() = VaccinationSlotDtoOut(
-        slotId = this[VaccinationSlots.id],
+        id = this[VaccinationSlots.id],
         locationId = this[VaccinationSlots.locationId],
         patientId = this[VaccinationSlots.patientId],
         from = this[VaccinationSlots.from],

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/repository/LocationRepository.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/repository/LocationRepository.kt
@@ -134,6 +134,7 @@ class LocationRepository {
         id = this[VaccinationSlots.id],
         locationId = this[VaccinationSlots.locationId],
         patientId = this[VaccinationSlots.patientId],
+        queue = this[VaccinationSlots.queue],
         from = this[VaccinationSlots.from],
         to = this[VaccinationSlots.to]
     )

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/repository/VaccinationSlotRepository.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/repository/VaccinationSlotRepository.kt
@@ -1,0 +1,77 @@
+package blue.mild.covid.vaxx.dao.repository
+
+import blue.mild.covid.vaxx.dao.model.EntityId
+import blue.mild.covid.vaxx.dao.model.VaccinationSlots
+import blue.mild.covid.vaxx.dao.model.Vaccinations
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.sql.update
+import java.time.Instant
+
+@Suppress("LongParameterList") // it's a repository, we're fine with this
+class VaccinationSlotRepository {
+    /**
+     * Creates new vaccination slot record for given data.
+     */
+    suspend fun addVaccinationSlot(
+        locationId: EntityId,
+        patientId: EntityId? = null,
+        from: Instant,
+        to: Instant,
+    ): EntityId = newSuspendedTransaction {
+        VaccinationSlots.insert {
+            it[VaccinationSlots.patientId] = patientId
+            it[VaccinationSlots.locationId] = locationId
+            it[VaccinationSlots.from] = from
+            it[VaccinationSlots.to] = to
+        }[Vaccinations.id]
+    }
+
+    /**
+     * Updates vaccination slot entity with id [vaccinationSlotId].
+     */
+    suspend fun updateVaccinationSlot(
+        vaccinationSlotId: EntityId,
+        locationId: EntityId? = null,
+        patientId: EntityId? = null,
+        from: Instant? = null,
+        to: Instant? = null,
+    ): Boolean = newSuspendedTransaction {
+        val isUpdateNecessary =
+            locationId ?: patientId
+            ?: from ?: to
+
+        // if so, perform update query
+        val vaccinationUpdated = if (isUpdateNecessary != null) {
+            Vaccinations.update(
+                where = { VaccinationSlots.id eq vaccinationSlotId },
+                body = { row ->
+                    row.apply {
+                        updateIfNotNull(locationId, VaccinationSlots.locationId)
+                        updateIfNotNull(patientId, VaccinationSlots.patientId)
+                        updateIfNotNull(from, VaccinationSlots.from)
+                        updateIfNotNull(to, VaccinationSlots.to)
+                    }
+                }
+            )
+        } else 0
+        vaccinationUpdated == 1
+    }
+
+//    private suspend fun get(where: SqlExpressionBuilder.() -> Op<Boolean>) =
+//        newSuspendedTransaction {
+//            VaccinationSlots
+//                .select(where)
+//                .singleOrNull()
+//                ?.let {
+//                    VaccinationSlotDtoOut(
+//                        slotId = it[VaccinationSlots.id],
+//                        locationId = it[VaccinationSlots.locationId],
+//                        patientId = it[VaccinationSlots.patientId],
+//                        from = it[VaccinationSlots.from],
+//                        to = it[VaccinationSlots.to]
+//                    )
+//                }
+//        }
+
+}

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/repository/VaccinationSlotRepository.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/repository/VaccinationSlotRepository.kt
@@ -56,7 +56,7 @@ class VaccinationSlotRepository {
                 .orderBy(VaccinationSlots.from)
                 .orderBy(VaccinationSlots.queue)
                 .orderBy(VaccinationSlots.id)
-                ?.let { data ->
+                .let { data ->
                     data.map {
                         VaccinationSlotDtoOut(
                             id = it[VaccinationSlots.id],

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/repository/VaccinationSlotRepository.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/repository/VaccinationSlotRepository.kt
@@ -3,7 +3,11 @@ package blue.mild.covid.vaxx.dao.repository
 import blue.mild.covid.vaxx.dao.model.EntityId
 import blue.mild.covid.vaxx.dao.model.VaccinationSlots
 import blue.mild.covid.vaxx.dao.model.Vaccinations
+import blue.mild.covid.vaxx.dto.response.VaccinationSlotDtoOut
+import org.jetbrains.exposed.sql.Op
+import org.jetbrains.exposed.sql.SqlExpressionBuilder
 import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
 import org.jetbrains.exposed.sql.update
 import java.time.Instant
@@ -24,7 +28,7 @@ class VaccinationSlotRepository {
             it[VaccinationSlots.locationId] = locationId
             it[VaccinationSlots.from] = from
             it[VaccinationSlots.to] = to
-        }[Vaccinations.id]
+        }[VaccinationSlots.id]
     }
 
     /**
@@ -58,20 +62,21 @@ class VaccinationSlotRepository {
         vaccinationUpdated == 1
     }
 
-//    private suspend fun get(where: SqlExpressionBuilder.() -> Op<Boolean>) =
-//        newSuspendedTransaction {
-//            VaccinationSlots
-//                .select(where)
-//                .singleOrNull()
-//                ?.let {
-//                    VaccinationSlotDtoOut(
-//                        slotId = it[VaccinationSlots.id],
-//                        locationId = it[VaccinationSlots.locationId],
-//                        patientId = it[VaccinationSlots.patientId],
-//                        from = it[VaccinationSlots.from],
-//                        to = it[VaccinationSlots.to]
-//                    )
-//                }
-//        }
+    suspend fun get(where: SqlExpressionBuilder.() -> Op<Boolean>) =
+        newSuspendedTransaction {
+            VaccinationSlots
+                .select(where)
+                ?.let {
+                    data -> data.map {
+                        VaccinationSlotDtoOut(
+                            id = it[VaccinationSlots.id],
+                            locationId = it[VaccinationSlots.locationId],
+                            patientId = it[VaccinationSlots.patientId],
+                            from = it[VaccinationSlots.from],
+                            to = it[VaccinationSlots.to]
+                        )
+                    }
+                }
+        }
 
 }

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/repository/VaccinationSlotRepository.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/repository/VaccinationSlotRepository.kt
@@ -19,12 +19,14 @@ class VaccinationSlotRepository {
     suspend fun addVaccinationSlot(
         locationId: EntityId,
         patientId: EntityId? = null,
+        queue: Int,
         from: Instant,
         to: Instant,
     ): EntityId = newSuspendedTransaction {
         VaccinationSlots.insert {
             it[VaccinationSlots.patientId] = patientId
             it[VaccinationSlots.locationId] = locationId
+            it[VaccinationSlots.queue] = queue
             it[VaccinationSlots.from] = from
             it[VaccinationSlots.to] = to
         }[VaccinationSlots.id]
@@ -52,6 +54,7 @@ class VaccinationSlotRepository {
             VaccinationSlots
                 .select(where)
                 .orderBy(VaccinationSlots.from)
+                .orderBy(VaccinationSlots.queue)
                 .orderBy(VaccinationSlots.id)
                 ?.let { data ->
                     data.map {
@@ -59,6 +62,7 @@ class VaccinationSlotRepository {
                             id = it[VaccinationSlots.id],
                             locationId = it[VaccinationSlots.locationId],
                             patientId = it[VaccinationSlots.patientId],
+                            queue = it[VaccinationSlots.queue],
                             from = it[VaccinationSlots.from],
                             to = it[VaccinationSlots.to]
                         )

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/CreateVaccinationSlotsDtoIn.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/CreateVaccinationSlotsDtoIn.kt
@@ -4,8 +4,26 @@ import blue.mild.covid.vaxx.dao.model.EntityId
 import java.time.Instant
 
 data class CreateVaccinationSlotsDtoIn(
+    /**
+     * Location id
+     */
     val locationId: EntityId? = null,
+    /**
+     * When the location opens.
+     */
     val from: Instant,
+    /**
+     * When the location closes.
+     */
     val to: Instant,
+    /**
+     * How many people can be vaccinated in parallel.
+     *
+     * Number of queues.
+     */
+    val bandwidth: Int,
+    /**
+     * How long it takes to vaccinate single person.
+     */
     val durationMillis: Long
 )

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/CreateVaccinationSlotsDtoIn.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/CreateVaccinationSlotsDtoIn.kt
@@ -1,8 +1,10 @@
 package blue.mild.covid.vaxx.dto.request
 
+import blue.mild.covid.vaxx.dao.model.EntityId
 import java.time.Instant
 
 data class CreateVaccinationSlotsDtoIn(
+    val locationId: EntityId? = null,
     val from: Instant,
     val to: Instant,
     val durationSec: Int

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/CreateVaccinationSlotsDtoIn.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/CreateVaccinationSlotsDtoIn.kt
@@ -1,0 +1,9 @@
+package blue.mild.covid.vaxx.dto.request
+
+import java.time.Instant
+
+data class CreateVaccinationSlotsDtoIn(
+    val from: Instant,
+    val to: Instant,
+    val durationSec: Int
+)

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/CreateVaccinationSlotsDtoIn.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/CreateVaccinationSlotsDtoIn.kt
@@ -7,5 +7,5 @@ data class CreateVaccinationSlotsDtoIn(
     val locationId: EntityId? = null,
     val from: Instant,
     val to: Instant,
-    val durationSec: Int
+    val durationMillis: Long
 )

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/LocationDtoIn.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/LocationDtoIn.kt
@@ -1,0 +1,10 @@
+package blue.mild.covid.vaxx.dto.request
+
+data class LocationDtoIn(
+    val address: String,
+    val zipCode: Int,
+    val district: String,
+    val phoneNumber: PhoneNumberDtoIn? = null,
+    val email: String? = null,
+    val note: String? = null
+)

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/LocationDtoIn.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/LocationDtoIn.kt
@@ -6,5 +6,5 @@ data class LocationDtoIn(
     val district: String,
     val phoneNumber: PhoneNumberDtoIn? = null,
     val email: String? = null,
-    val note: String? = null
+    val notes: String? = null
 )

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/PatientVaccinationSlotSelectionDtoIn.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/PatientVaccinationSlotSelectionDtoIn.kt
@@ -1,0 +1,7 @@
+package blue.mild.covid.vaxx.dto.request
+
+import blue.mild.covid.vaxx.dao.model.EntityId
+
+data class PatientVaccinationSlotSelectionDtoIn(
+    val patientId: EntityId? = null
+)

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/query/LocationIdDtoIn.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/query/LocationIdDtoIn.kt
@@ -1,0 +1,8 @@
+package blue.mild.covid.vaxx.dto.request.query
+
+import blue.mild.covid.vaxx.dao.model.EntityId
+import com.papsign.ktor.openapigen.annotations.Path
+import com.papsign.ktor.openapigen.annotations.parameters.PathParam
+
+@Path("{id}")
+data class LocationIdDtoIn(@PathParam("Location ID") val id: EntityId)

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/query/MultipleVaccinationSlotsQueryDtoOut.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/query/MultipleVaccinationSlotsQueryDtoOut.kt
@@ -1,0 +1,20 @@
+package blue.mild.covid.vaxx.dto.request.query
+
+import blue.mild.covid.vaxx.dao.model.EntityId
+import com.papsign.ktor.openapigen.annotations.parameters.QueryParam
+
+data class MultipleVaccinationSlotsQueryDtoOut(
+    @QueryParam("Filter by location id.") val locationId: EntityId?,
+    @QueryParam("Filter with from greater or equal to.") val fromMillis: Long?,
+    @QueryParam("Filter with to lower or equal to.") val toMillis: Long?,
+    @QueryParam("Filter only free slots?.") val onlyFree: Boolean?,
+
+) {
+    override fun toString(): String =
+        listOfNotNull(
+            locationId?.let { "locationId=$it" },
+            fromMillis?.let { "fromMillis=$it" },
+            toMillis?.let { "toMillis=$it" },
+            onlyFree?.let { "onlyFree=$it" },
+        ).joinToString(", ", prefix = "query(", postfix = ")")
+}

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/query/MultipleVaccinationSlotsQueryDtoOut.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/query/MultipleVaccinationSlotsQueryDtoOut.kt
@@ -12,6 +12,7 @@ enum class VaccinationSlotStatus(val status: Int) {
 data class MultipleVaccinationSlotsQueryDtoOut(
     @QueryParam("Filter by slot id.") val id: EntityId?,
     @QueryParam("Filter by location id.") val locationId: EntityId?,
+    @QueryParam("Filter by patient id.") val patientId: EntityId?,
     @QueryParam("Filter with from greater or equal to.") val fromMillis: Long?,
     @QueryParam("Filter with to lower or equal to.") val toMillis: Long?,
     @QueryParam("Filter only free slots?.") val status: VaccinationSlotStatus?,
@@ -21,6 +22,7 @@ data class MultipleVaccinationSlotsQueryDtoOut(
         listOfNotNull(
             id?.let { "id=$it" },
             locationId?.let { "locationId=$it" },
+            patientId?.let { "patientId=$it" },
             fromMillis?.let { "fromMillis=$it" },
             toMillis?.let { "toMillis=$it" },
             status?.let { "status=$it" },

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/query/MultipleVaccinationSlotsQueryDtoOut.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/query/MultipleVaccinationSlotsQueryDtoOut.kt
@@ -3,18 +3,26 @@ package blue.mild.covid.vaxx.dto.request.query
 import blue.mild.covid.vaxx.dao.model.EntityId
 import com.papsign.ktor.openapigen.annotations.parameters.QueryParam
 
+enum class VaccinationSlotStatus(val status: Int) {
+    ALL(0),
+    ONLY_FREE(1),
+    ONLY_OCCUPIED(2),
+}
+
 data class MultipleVaccinationSlotsQueryDtoOut(
+    @QueryParam("Filter by slot id.") val id: EntityId?,
     @QueryParam("Filter by location id.") val locationId: EntityId?,
     @QueryParam("Filter with from greater or equal to.") val fromMillis: Long?,
     @QueryParam("Filter with to lower or equal to.") val toMillis: Long?,
-    @QueryParam("Filter only free slots?.") val onlyFree: Boolean?,
+    @QueryParam("Filter only free slots?.") val status: VaccinationSlotStatus?,
 
 ) {
     override fun toString(): String =
         listOfNotNull(
+            id?.let { "id=$it" },
             locationId?.let { "locationId=$it" },
             fromMillis?.let { "fromMillis=$it" },
             toMillis?.let { "toMillis=$it" },
-            onlyFree?.let { "onlyFree=$it" },
+            status?.let { "status=$it" },
         ).joinToString(", ", prefix = "query(", postfix = ")")
 }

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/response/LocationDtoOut.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/response/LocationDtoOut.kt
@@ -1,0 +1,16 @@
+package blue.mild.covid.vaxx.dto.response
+
+import blue.mild.covid.vaxx.dao.model.EntityId
+import blue.mild.covid.vaxx.dao.model.InsuranceCompany
+import java.time.Instant
+
+data class LocationDtoOut(
+    val id: EntityId,
+    val address: String,
+    val zipCode: Int,
+    val district: String,
+    val phoneNumber: String? = null,
+    val email: String? = null,
+    val note: String? = null,
+    val slots: List<VaccinationSlotDtoOut>
+)

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/response/LocationDtoOut.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/response/LocationDtoOut.kt
@@ -1,8 +1,6 @@
 package blue.mild.covid.vaxx.dto.response
 
 import blue.mild.covid.vaxx.dao.model.EntityId
-import blue.mild.covid.vaxx.dao.model.InsuranceCompany
-import java.time.Instant
 
 data class LocationDtoOut(
     val id: EntityId,
@@ -11,6 +9,6 @@ data class LocationDtoOut(
     val district: String,
     val phoneNumber: String? = null,
     val email: String? = null,
-    val note: String? = null,
+    val notes: String? = null,
     val slots: List<VaccinationSlotDtoOut>
 )

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/response/VaccinationSlotDtoOut.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/response/VaccinationSlotDtoOut.kt
@@ -4,7 +4,7 @@ import blue.mild.covid.vaxx.dao.model.EntityId
 import java.time.Instant
 
 data class VaccinationSlotDtoOut(
-    val slotId: EntityId,
+    val id: EntityId,
     val locationId: EntityId,
     val patientId: EntityId?,
     val from: Instant,

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/response/VaccinationSlotDtoOut.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/response/VaccinationSlotDtoOut.kt
@@ -1,0 +1,12 @@
+package blue.mild.covid.vaxx.dto.response
+
+import blue.mild.covid.vaxx.dao.model.EntityId
+import java.time.Instant
+
+data class VaccinationSlotDtoOut(
+    val slotId: EntityId,
+    val locationId: EntityId,
+    val patientId: EntityId?,
+    val from: Instant,
+    val to: Instant
+)

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/response/VaccinationSlotDtoOut.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/response/VaccinationSlotDtoOut.kt
@@ -7,6 +7,7 @@ data class VaccinationSlotDtoOut(
     val id: EntityId,
     val locationId: EntityId,
     val patientId: EntityId?,
+    val queue: Int,
     val from: Instant,
     val to: Instant
 )

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/LocationRoutes.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/LocationRoutes.kt
@@ -2,9 +2,13 @@ package blue.mild.covid.vaxx.routes
 
 import blue.mild.covid.vaxx.dao.model.EntityId
 import blue.mild.covid.vaxx.dao.model.UserRole
+import blue.mild.covid.vaxx.dao.model.VaccinationSlots.locationId
+import blue.mild.covid.vaxx.dto.request.CreateVaccinationSlotsDtoIn
 import blue.mild.covid.vaxx.dto.request.LocationDtoIn
 import blue.mild.covid.vaxx.dto.request.query.LocationIdDtoIn
 import blue.mild.covid.vaxx.dto.response.LocationDtoOut
+import blue.mild.covid.vaxx.dto.response.OK
+import blue.mild.covid.vaxx.dto.response.Ok
 import blue.mild.covid.vaxx.extensions.determineRealIp
 import blue.mild.covid.vaxx.extensions.di
 import blue.mild.covid.vaxx.extensions.request
@@ -52,11 +56,40 @@ fun NormalOpenAPIRoute.locationRoutes() {
     }
 
     authorizeRoute {
-        route(Routes.userLoginVerification) {
-            get<Unit, Unit, UserPrincipal>(
+        route(Routes.locationsSlots) {
+            get<LocationIdDtoIn, Unit, UserPrincipal>(
                 info("Verify that the currently used token is valid. Returns 200 if token is correct, 401 otherwise.")
-            ) {
+            ) { (locationId) ->
+                logger.info {
+                    "Get slots for location ${locationId} from host ${request.determineRealIp()}."
+                }
                 respondWithStatus(HttpStatusCode.OK)
+            }
+
+            /*
+            // MartinLlama - When tests are executed then when calling POST .../locations/{id}/slots returns 404
+            post<LocationIdDtoIn, Ok, /*EntityId, */CreateVaccinationSlotsDtoIn, UserPrincipal>(
+                info("Add new slots for location.")
+            ) { locationId, createSlots ->
+                val principal = principal()
+                logger.info {
+                    "For location ${locationId} adding slots ${createSlots} registered by ${principal.userId} from host ${request.determineRealIp()}."
+                }
+                // respond(locationService.addLocation(location))
+                respond(OK)
+            }
+            */
+
+            // MartinLLama - When tests are executed then locationId is not extracted
+            post<Unit, Ok, /*EntityId, */CreateVaccinationSlotsDtoIn, UserPrincipal>(
+                info("Add new slots for location.")
+            ) { _, createSlots ->
+                val principal = principal()
+                logger.info {
+                    "For location ${locationId} adding slots ${createSlots} registered by ${principal.userId} from host ${request.determineRealIp()}."
+                }
+                // respond(locationService.addLocation(location))
+                respond(OK)
             }
         }
     }

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/LocationRoutes.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/LocationRoutes.kt
@@ -2,7 +2,6 @@ package blue.mild.covid.vaxx.routes
 
 import blue.mild.covid.vaxx.dao.model.EntityId
 import blue.mild.covid.vaxx.dao.model.UserRole
-import blue.mild.covid.vaxx.dto.request.CreateVaccinationSlotsDtoIn
 import blue.mild.covid.vaxx.dto.request.LocationDtoIn
 import blue.mild.covid.vaxx.dto.request.query.LocationIdDtoIn
 import blue.mild.covid.vaxx.dto.response.LocationDtoOut
@@ -28,7 +27,6 @@ import org.kodein.di.instance
  */
 fun NormalOpenAPIRoute.locationRoutes() {
     val locationService by di().instance<LocationService>()
-    val vaccinationSlotService by di().instance<VaccinationSlotService>()
 
     val logger = createLogger("LocationRoutes")
 
@@ -50,19 +48,19 @@ fun NormalOpenAPIRoute.locationRoutes() {
                 respond(locationService.getLocationById(locationId))
             }
 
-            // MartinLLama - Locations: I am trying to make endpoint /locations/{id}/slots - this does not work
-            // https://ktor.io/docs/routing-in-ktor.html#multiple_routes - based on sub-routes
-            route("/slots") {
-                post<LocationIdDtoIn, List<EntityId>, CreateVaccinationSlotsDtoIn, UserPrincipal>(
-                    info("Add new vaccination slots into the system.")
-                ) { location, createSlots ->
-                    val principal = principal()
-                    logger.info {
-                        "For location ${location} adding slots ${createSlots} by ${principal.userId} from host ${request.determineRealIp()}."
-                    }
-                    respond(vaccinationSlotService.addSlots(createSlots, location.id))
-                }
-            }
+//            // MartinLLama - Locations: I am trying to make endpoint /locations/{id}/slots - this does not work
+//            // https://ktor.io/docs/routing-in-ktor.html#multiple_routes - based on sub-routes
+//            route("/slots") {
+//                post<LocationIdDtoIn, List<EntityId>, CreateVaccinationSlotsDtoIn, UserPrincipal>(
+//                    info("Add new vaccination slots into the system.")
+//                ) { location, createSlots ->
+//                    val principal = principal()
+//                    logger.info {
+//                        "For location ${location} adding slots ${createSlots} by ${principal.userId} from host ${request.determineRealIp()}."
+//                    }
+//                    respond(vaccinationSlotService.addSlots(createSlots, location.id))
+//                }
+//            }
         }
 
 // MartinLLama - Locations: I am trying to make endpoint /locations/{id}/slots - this does not work

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/LocationRoutes.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/LocationRoutes.kt
@@ -1,0 +1,63 @@
+package blue.mild.covid.vaxx.routes
+
+import blue.mild.covid.vaxx.dao.model.EntityId
+import blue.mild.covid.vaxx.dao.model.UserRole
+import blue.mild.covid.vaxx.dto.request.LocationDtoIn
+import blue.mild.covid.vaxx.dto.request.query.LocationIdDtoIn
+import blue.mild.covid.vaxx.dto.response.LocationDtoOut
+import blue.mild.covid.vaxx.extensions.determineRealIp
+import blue.mild.covid.vaxx.extensions.di
+import blue.mild.covid.vaxx.extensions.request
+import blue.mild.covid.vaxx.extensions.respondWithStatus
+import blue.mild.covid.vaxx.security.auth.UserPrincipal
+import blue.mild.covid.vaxx.security.auth.authorizeRoute
+import blue.mild.covid.vaxx.service.LocationService
+import blue.mild.covid.vaxx.utils.createLogger
+import com.papsign.ktor.openapigen.route.info
+import com.papsign.ktor.openapigen.route.path.auth.get
+import com.papsign.ktor.openapigen.route.path.auth.post
+import com.papsign.ktor.openapigen.route.path.auth.principal
+import com.papsign.ktor.openapigen.route.path.normal.NormalOpenAPIRoute
+import com.papsign.ktor.openapigen.route.response.respond
+import com.papsign.ktor.openapigen.route.route
+import io.ktor.http.HttpStatusCode
+import org.kodein.di.instance
+
+/**
+ * Routes associated with the user logins and authorizations.
+ */
+fun NormalOpenAPIRoute.locationRoutes() {
+    val locationService by di().instance<LocationService>()
+
+    val logger = createLogger("LocationRoutes")
+
+    authorizeRoute(requireOneOf = setOf(UserRole.ADMIN)) {
+        route(Routes.locations) {
+            post<Unit, EntityId, LocationDtoIn, UserPrincipal>(
+                info("Add new location into the system.")
+            ) { _, location ->
+                val principal = principal()
+                logger.info {
+                    "Adding location ${location.address}, ${location.zipCode} registered by ${principal.userId} from host ${request.determineRealIp()}."
+                }
+                respond(locationService.addLocation(location))
+            }
+
+            get<LocationIdDtoIn, LocationDtoOut, UserPrincipal>(
+                info("Get location detail by given location id.")
+            ) { (locationId) ->
+                respond(locationService.getLocationById(locationId))
+            }
+        }
+    }
+
+    authorizeRoute {
+        route(Routes.userLoginVerification) {
+            get<Unit, Unit, UserPrincipal>(
+                info("Verify that the currently used token is valid. Returns 200 if token is correct, 401 otherwise.")
+            ) {
+                respondWithStatus(HttpStatusCode.OK)
+            }
+        }
+    }
+}

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/NurseRoutes.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/NurseRoutes.kt
@@ -38,6 +38,7 @@ fun NormalOpenAPIRoute.nurseRoutes() {
 
     authorizeRoute(requireOneOf = setOf(UserRole.ADMIN)) {
         route(Routes.nurse) {
+            // RESTFUL: This should be PUT
             put<Unit, Ok, NurseCreationDtoIn, UserPrincipal>(
                 info("Creates nurse entity.")
             ) { _, request ->

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/Routes.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/Routes.kt
@@ -23,6 +23,8 @@ object Routes {
     val locations = adminRoute("locations")
     val locationsSlots = adminRoute("locations/{id}/slots")
 
+    val vaccinationSlots = adminRoute("vaccination-slots")
+
     val adminSectionPatient = adminRoute("patient")
     val vaccination = adminRoute("vaccination")
     val nurse = adminRoute("nurse")

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/Routes.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/Routes.kt
@@ -21,6 +21,7 @@ object Routes {
     val userLoginVerification = adminRoute("self")
 
     val locations = adminRoute("locations")
+    val locationsSlots = adminRoute("locations/{id}/slots")
 
     val adminSectionPatient = adminRoute("patient")
     val vaccination = adminRoute("vaccination")

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/Routes.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/Routes.kt
@@ -20,6 +20,8 @@ object Routes {
     val userRegistration = adminRoute("register")
     val userLoginVerification = adminRoute("self")
 
+    val locations = adminRoute("locations")
+
     val adminSectionPatient = adminRoute("patient")
     val vaccination = adminRoute("vaccination")
     val nurse = adminRoute("nurse")

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/RoutesSetup.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/RoutesSetup.kt
@@ -11,6 +11,7 @@ fun NormalOpenAPIRoute.registerRoutes() {
     insuranceCompanyRoutes()
     userRoutes()
     locationRoutes()
+    vaccinationSlotRoutes()
     serviceRoutes()
     vaccinationRoutes()
     dataCorrectnessRoutes()

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/RoutesSetup.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/RoutesSetup.kt
@@ -10,6 +10,7 @@ fun NormalOpenAPIRoute.registerRoutes() {
     questionRoutes()
     insuranceCompanyRoutes()
     userRoutes()
+    locationRoutes()
     serviceRoutes()
     vaccinationRoutes()
     dataCorrectnessRoutes()

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/VaccinationSlotRoutes.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/VaccinationSlotRoutes.kt
@@ -52,6 +52,7 @@ fun NormalOpenAPIRoute.vaccinationSlotRoutes() {
                     val slots = vaccinationSlotService.getSlotsByConjunctionOf(
                         id = slotsQuery.id,
                         locationId = slotsQuery.locationId,
+                        patientId = slotsQuery.patientId,
                         fromMillis = slotsQuery.fromMillis,
                         toMillis = slotsQuery.toMillis,
                         status = slotsQuery.status,
@@ -72,10 +73,11 @@ fun NormalOpenAPIRoute.vaccinationSlotRoutes() {
                     val slot = vaccinationSlotService.updateSlot(
                         id = slotsQuery.id,
                         locationId = slotsQuery.locationId,
+                        patientId = slotsQuery.patientId,
                         fromMillis = slotsQuery.fromMillis,
                         toMillis = slotsQuery.toMillis,
                         status = slotsQuery.status,
-                        patientId = patientDtoIn.patientId,
+                        newPatientId = patientDtoIn.patientId,
                     )
 
                     logger.info { "Updated ${slot} record." }

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/VaccinationSlotRoutes.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/VaccinationSlotRoutes.kt
@@ -52,8 +52,8 @@ fun NormalOpenAPIRoute.vaccinationSlotRoutes() {
                     val slots = vaccinationSlotService.getSlotsByConjunctionOf(
                         id = slotsQuery.id,
                         locationId = slotsQuery.locationId,
-                        fromMillis = slotsQuery?.fromMillis,
-                        toMillis = slotsQuery?.toMillis,
+                        fromMillis = slotsQuery.fromMillis,
+                        toMillis = slotsQuery.toMillis,
                         status = slotsQuery.status,
                     )
 
@@ -72,8 +72,8 @@ fun NormalOpenAPIRoute.vaccinationSlotRoutes() {
                     val slot = vaccinationSlotService.updateSlot(
                         id = slotsQuery.id,
                         locationId = slotsQuery.locationId,
-                        fromMillis = slotsQuery?.fromMillis,
-                        toMillis = slotsQuery?.toMillis,
+                        fromMillis = slotsQuery.fromMillis,
+                        toMillis = slotsQuery.toMillis,
                         status = slotsQuery.status,
                         patientId = patientDtoIn.patientId,
                     )

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/VaccinationSlotRoutes.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/VaccinationSlotRoutes.kt
@@ -1,0 +1,42 @@
+package blue.mild.covid.vaxx.routes
+
+import blue.mild.covid.vaxx.dao.model.EntityId
+import blue.mild.covid.vaxx.dao.model.UserRole
+import blue.mild.covid.vaxx.dto.request.CreateVaccinationSlotsDtoIn
+import blue.mild.covid.vaxx.extensions.determineRealIp
+import blue.mild.covid.vaxx.extensions.di
+import blue.mild.covid.vaxx.extensions.request
+import blue.mild.covid.vaxx.security.auth.UserPrincipal
+import blue.mild.covid.vaxx.security.auth.authorizeRoute
+import blue.mild.covid.vaxx.service.VaccinationSlotService
+import blue.mild.covid.vaxx.utils.createLogger
+import com.papsign.ktor.openapigen.route.info
+import com.papsign.ktor.openapigen.route.path.auth.post
+import com.papsign.ktor.openapigen.route.path.auth.principal
+import com.papsign.ktor.openapigen.route.path.normal.NormalOpenAPIRoute
+import com.papsign.ktor.openapigen.route.response.respond
+import com.papsign.ktor.openapigen.route.route
+import org.kodein.di.instance
+
+/**
+ * Routes associated with the user logins and authorizations.
+ */
+fun NormalOpenAPIRoute.vaccinationSlotRoutes() {
+    val vaccinationSlotService by di().instance<VaccinationSlotService>()
+
+    val logger = createLogger("LocationRoutes")
+
+    authorizeRoute(requireOneOf = setOf(UserRole.ADMIN)) {
+        route(Routes.vaccinationSlots) {
+            post<Unit, List<EntityId>, CreateVaccinationSlotsDtoIn, UserPrincipal>(
+                info("Add new location into the system.")
+            ) { location, createSlots ->
+                val principal = principal()
+                logger.info {
+                    "For location ${location} adding slots ${createSlots} by ${principal.userId} from host ${request.determineRealIp()}."
+                }
+                respond(vaccinationSlotService.addSlots(createSlots))
+            }
+        }
+    }
+}

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/VaccinationSlotRoutes.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/VaccinationSlotRoutes.kt
@@ -33,7 +33,7 @@ fun NormalOpenAPIRoute.vaccinationSlotRoutes() {
     authorizeRoute(requireOneOf = setOf(UserRole.ADMIN)) {
         route(Routes.vaccinationSlots) {
             post<Unit, List<EntityId>, CreateVaccinationSlotsDtoIn, UserPrincipal>(
-                info("Add new location into the system.")
+                info("Add new vaccination slots for given location.")
             ) { location, createSlots ->
                 val principal = principal()
                 logger.info {
@@ -44,7 +44,7 @@ fun NormalOpenAPIRoute.vaccinationSlotRoutes() {
 
             route("filter") {
                 get<MultipleVaccinationSlotsQueryDtoOut, List<VaccinationSlotDtoOut>, UserPrincipal>(
-                    info("Get patient the parameters. Filters by and clause. Empty parameters return all patients.")
+                    info("Get vaccination spots matching ")
                 ) { slotsQuery ->
                     val principal = principal()
                     logger.info { "User ${principal.userId} search query: $slotsQuery." }

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/service/LocationService.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/service/LocationService.kt
@@ -4,9 +4,12 @@ import blue.mild.covid.vaxx.dao.model.EntityId
 import blue.mild.covid.vaxx.dao.model.Locations
 import blue.mild.covid.vaxx.dao.model.Patients
 import blue.mild.covid.vaxx.dao.repository.LocationRepository
+import blue.mild.covid.vaxx.dto.request.LocationDtoIn
 import blue.mild.covid.vaxx.dto.response.LocationDtoOut
 import blue.mild.covid.vaxx.error.entityNotFound
+import blue.mild.covid.vaxx.utils.formatPhoneNumber
 import mu.KLogging
+import java.util.*
 
 class LocationService(
     private val locationRepository: LocationRepository,
@@ -45,33 +48,24 @@ class LocationService(
 //        ).whenFalse { throw entityNotFound<Patients>(Patients::id, patientId) }
 //    }
 //
-//    /**
-//     * Saves patient to the database and return its id.
-//     */
-//    suspend fun savePatient(registrationDto: ContextAware<PatientRegistrationDtoIn>): EntityId {
-//        val registration = registrationDto.payload
-//        logger.debug { "Registering patient ${registration.email}." }
-//
-//        logger.debug { "Registration validation." }
-//        validationService.requireValidRegistration(registration)
-//
-//        logger.debug { "Saving registration." }
-//        return patientRepository.savePatient(
-//            firstName = registration.firstName.trim(),
-//            lastName = registration.lastName.trim(),
-//            zipCode = registration.zipCode,
-//            district = registration.district.trim(),
-//            phoneNumber = registration.phoneNumber.formatPhoneNumber(),
-//            personalNumber = normalizePersonalNumber(registration.personalNumber),
-//            email = registration.email.trim().lowercase(Locale.getDefault()),
-//            insuranceCompany = registration.insuranceCompany,
-//            indication = registration.indication?.trim(),
-//            remoteHost = registrationDto.remoteHost,
-//            answers = registration.answers.associate { it.questionId to it.value }
-//        ).also { patientId ->
-//            logger.debug { "Patient ${registration.email} saved under id $patientId." }
-//        }
-//    }
+    /**
+     * Saves patient to the database and return its id.
+     */
+    suspend fun addLocation(location: LocationDtoIn): EntityId {
+        logger.debug { "Adding location ${location.address}, ${location.zipCode}." }
+
+        logger.debug { "Saving location." }
+        return locationRepository.saveLocation(
+            address = location.address.trim(),
+            zipCode = location.zipCode,
+            district = location.district.trim(),
+            phoneNumber = location.phoneNumber?.formatPhoneNumber(),
+            email = location.email?.trim()?.lowercase(Locale.getDefault()),
+            note = location.note?.trim()
+        ).also { locationId ->
+            logger.debug { "Location ${location.address} saved under id $locationId." }
+        }
+    }
 //
 //    /**
 //     * Deletes patient with given ID. Throws exception if patient was not deleted.

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/service/LocationService.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/service/LocationService.kt
@@ -2,7 +2,6 @@ package blue.mild.covid.vaxx.service
 
 import blue.mild.covid.vaxx.dao.model.EntityId
 import blue.mild.covid.vaxx.dao.model.Locations
-import blue.mild.covid.vaxx.dao.model.Patients
 import blue.mild.covid.vaxx.dao.repository.LocationRepository
 import blue.mild.covid.vaxx.dto.request.LocationDtoIn
 import blue.mild.covid.vaxx.dto.response.LocationDtoOut
@@ -25,7 +24,7 @@ class LocationService(
     suspend fun getLocationById(locationId: EntityId): LocationDtoOut =
         locationRepository.getAndMapLocationsBy { Locations.id eq locationId }
             .singleOrNull()
-            ?.withSortedSlots() ?: throw entityNotFound<Patients>(Locations::id, locationId)
+            ?.withSortedSlots() ?: throw entityNotFound<Locations>(Locations::id, locationId)
 
 //    /**
 //     * Updates patient with given change set.
@@ -61,7 +60,7 @@ class LocationService(
             district = location.district.trim(),
             phoneNumber = location.phoneNumber?.formatPhoneNumber(),
             email = location.email?.trim()?.lowercase(Locale.getDefault()),
-            note = location.note?.trim()
+            notes = location.notes?.trim()
         ).also { locationId ->
             logger.debug { "Location ${location.address} saved under id $locationId." }
         }

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/service/LocationService.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/service/LocationService.kt
@@ -1,0 +1,92 @@
+package blue.mild.covid.vaxx.service
+
+import blue.mild.covid.vaxx.dao.model.EntityId
+import blue.mild.covid.vaxx.dao.model.Locations
+import blue.mild.covid.vaxx.dao.model.Patients
+import blue.mild.covid.vaxx.dao.repository.LocationRepository
+import blue.mild.covid.vaxx.dto.response.LocationDtoOut
+import blue.mild.covid.vaxx.error.entityNotFound
+import mu.KLogging
+
+class LocationService(
+    private val locationRepository: LocationRepository,
+//    private val vaccinationSlotRepository: VaccinationSlotRepository,
+//    private val patientRepository: PatientRepository
+) {
+
+    private companion object : KLogging()
+
+    /**
+     * Returns patient with given ID.
+     */
+    suspend fun getLocationById(locationId: EntityId): LocationDtoOut =
+        locationRepository.getAndMapLocationsBy { Locations.id eq locationId }
+            .singleOrNull()
+            ?.withSortedSlots() ?: throw entityNotFound<Patients>(Locations::id, locationId)
+
+//    /**
+//     * Updates patient with given change set.
+//     */
+//    suspend fun updatePatientWithChangeSet(patientId: UUID, changeSet: PatientUpdateDtoIn) {
+//        validationService.requireValidPatientUpdate(changeSet)
+//
+//        patientRepository.updatePatientChangeSet(
+//            id = patientId,
+//            firstName = changeSet.firstName?.trim(),
+//            lastName = changeSet.lastName?.trim(),
+//            zipCode = changeSet.zipCode,
+//            district = changeSet.district?.trim(),
+//            phoneNumber = changeSet.phoneNumber?.formatPhoneNumber(),
+//            personalNumber = changeSet.personalNumber?.let { normalizePersonalNumber(it) },
+//            email = changeSet.email?.trim()?.lowercase(Locale.getDefault()),
+//            insuranceCompany = changeSet.insuranceCompany,
+//            indication = changeSet.indication?.trim(),
+//            answers = changeSet.answers?.associate { it.questionId to it.value }
+//        ).whenFalse { throw entityNotFound<Patients>(Patients::id, patientId) }
+//    }
+//
+//    /**
+//     * Saves patient to the database and return its id.
+//     */
+//    suspend fun savePatient(registrationDto: ContextAware<PatientRegistrationDtoIn>): EntityId {
+//        val registration = registrationDto.payload
+//        logger.debug { "Registering patient ${registration.email}." }
+//
+//        logger.debug { "Registration validation." }
+//        validationService.requireValidRegistration(registration)
+//
+//        logger.debug { "Saving registration." }
+//        return patientRepository.savePatient(
+//            firstName = registration.firstName.trim(),
+//            lastName = registration.lastName.trim(),
+//            zipCode = registration.zipCode,
+//            district = registration.district.trim(),
+//            phoneNumber = registration.phoneNumber.formatPhoneNumber(),
+//            personalNumber = normalizePersonalNumber(registration.personalNumber),
+//            email = registration.email.trim().lowercase(Locale.getDefault()),
+//            insuranceCompany = registration.insuranceCompany,
+//            indication = registration.indication?.trim(),
+//            remoteHost = registrationDto.remoteHost,
+//            answers = registration.answers.associate { it.questionId to it.value }
+//        ).also { patientId ->
+//            logger.debug { "Patient ${registration.email} saved under id $patientId." }
+//        }
+//    }
+//
+//    /**
+//     * Deletes patient with given ID. Throws exception if patient was not deleted.
+//     * */
+//    suspend fun deletePatientById(patientId: UUID) {
+//        val deletedCount = patientRepository.deletePatientsBy { Patients.id eq patientId }
+//        if (deletedCount != 1) {
+//            throw entityNotFound<Patients>(Patients::id, patientId)
+//        }
+//    }
+
+//    private fun List<LocationDtoOut>.sorted() = map { it.withSortedSlots() }
+
+    private fun LocationDtoOut.withSortedSlots() = copy(slots = slots.sortedBy { it.from })
+
+//    private fun <T> Op<Boolean>.andWithIfNotEmpty(value: T?, column: Column<T>): Op<Boolean> =
+//        value?.let { and { column eq value } } ?: this
+}

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/service/VaccinationSlotService.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/service/VaccinationSlotService.kt
@@ -16,8 +16,8 @@ import org.jetbrains.exposed.sql.and
 import java.time.Instant
 
 @Suppress("MagicNumber")
-val MAX_FUTURE = Instant.now().plusMillis(2*365*24*60*60*1000)
-val DEFAULT_STATUS = VaccinationSlotStatus.ONLY_FREE
+val MAX_FUTURE: Instant = Instant.now().plusMillis(2*365*24*60*60*1000)
+val DEFAULT_STATUS: VaccinationSlotStatus = VaccinationSlotStatus.ONLY_FREE
 
 class VaccinationSlotService(
     private val locationRepository: LocationRepository,

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/service/VaccinationSlotService.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/service/VaccinationSlotService.kt
@@ -44,14 +44,17 @@ class VaccinationSlotService(
         val createdIds = mutableListOf<EntityId>()
         while (ts.plusMillis(createDto.durationMillis).isBefore(createDto.to.plusMillis(1))) {
             val to = ts.plusMillis(createDto.durationMillis)
-            createdIds.add(
-                vaccinationSlotRepository.addVaccinationSlot(
-                    locationId=location.id,
-                    patientId = null,
-                    from = ts,
-                    to = to,
+            for (queue in 0 until createDto.bandwidth) {
+                createdIds.add(
+                    vaccinationSlotRepository.addVaccinationSlot(
+                        locationId = location.id,
+                        patientId = null,
+                        queue = queue,
+                        from = ts,
+                        to = to,
+                    )
                 )
-            )
+            }
             ts = to
         }
 

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/service/VaccinationSlotService.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/service/VaccinationSlotService.kt
@@ -1,0 +1,101 @@
+package blue.mild.covid.vaxx.service
+
+import blue.mild.covid.vaxx.dao.model.EntityId
+import blue.mild.covid.vaxx.dao.model.Locations
+import blue.mild.covid.vaxx.dao.repository.LocationRepository
+import blue.mild.covid.vaxx.dao.repository.VaccinationSlotRepository
+import blue.mild.covid.vaxx.dto.request.CreateVaccinationSlotsDtoIn
+import blue.mild.covid.vaxx.dto.request.LocationDtoIn
+import blue.mild.covid.vaxx.dto.response.LocationDtoOut
+import blue.mild.covid.vaxx.error.entityNotFound
+import blue.mild.covid.vaxx.utils.formatPhoneNumber
+import mu.KLogging
+import java.util.*
+
+class VaccinationSlotService(
+    private val locationRepository: LocationRepository,
+    private val vaccinationSlotRepository: VaccinationSlotRepository,
+//    private val patientRepository: PatientRepository
+) {
+
+    private companion object : KLogging()
+
+    suspend fun addSlots(createDto: CreateVaccinationSlotsDtoIn, locationId: EntityId? = null): List<EntityId> {
+        if (createDto.locationId != null && locationId != null) {
+            throw Exception("Location mismatch - ${createDto} vs ${locationId}")
+        }
+        val usedLocationId = createDto.locationId ?: locationId
+        assert(usedLocationId != null)
+
+        val location = locationRepository.getAndMapLocationsBy { Locations.id eq usedLocationId!! }
+            .singleOrNull()
+            ?.withSortedSlots() ?: throw entityNotFound<Locations>(Locations::id, usedLocationId!!)
+
+        return listOf()
+    }
+
+    /**
+     * Returns patient with given ID.
+     */
+    suspend fun getLocationById(locationId: EntityId): LocationDtoOut =
+        locationRepository.getAndMapLocationsBy { Locations.id eq locationId }
+            .singleOrNull()
+            ?.withSortedSlots() ?: throw entityNotFound<Locations>(Locations::id, locationId)
+
+//    /**
+//     * Updates patient with given change set.
+//     */
+//    suspend fun updatePatientWithChangeSet(patientId: UUID, changeSet: PatientUpdateDtoIn) {
+//        validationService.requireValidPatientUpdate(changeSet)
+//
+//        patientRepository.updatePatientChangeSet(
+//            id = patientId,
+//            firstName = changeSet.firstName?.trim(),
+//            lastName = changeSet.lastName?.trim(),
+//            zipCode = changeSet.zipCode,
+//            district = changeSet.district?.trim(),
+//            phoneNumber = changeSet.phoneNumber?.formatPhoneNumber(),
+//            personalNumber = changeSet.personalNumber?.let { normalizePersonalNumber(it) },
+//            email = changeSet.email?.trim()?.lowercase(Locale.getDefault()),
+//            insuranceCompany = changeSet.insuranceCompany,
+//            indication = changeSet.indication?.trim(),
+//            answers = changeSet.answers?.associate { it.questionId to it.value }
+//        ).whenFalse { throw entityNotFound<Patients>(Patients::id, patientId) }
+//    }
+//
+    /**
+     * Saves patient to the database and return its id.
+     */
+    suspend fun addLocation(location: LocationDtoIn): EntityId {
+        logger.debug { "Adding location ${location.address}, ${location.zipCode}." }
+
+        logger.debug { "Saving location." }
+        return locationRepository.saveLocation(
+            address = location.address.trim(),
+            zipCode = location.zipCode,
+            district = location.district.trim(),
+            phoneNumber = location.phoneNumber?.formatPhoneNumber(),
+            email = location.email?.trim()?.lowercase(Locale.getDefault()),
+            notes = location.notes?.trim()
+        ).also { locationId ->
+            logger.debug { "Location ${location.address} saved under id $locationId." }
+        }
+    }
+//
+//    /**
+//     * Deletes patient with given ID. Throws exception if patient was not deleted.
+//     * */
+//    suspend fun deletePatientById(patientId: UUID) {
+//        val deletedCount = patientRepository.deletePatientsBy { Patients.id eq patientId }
+//        if (deletedCount != 1) {
+//            throw entityNotFound<Patients>(Patients::id, patientId)
+//        }
+//    }
+
+//    private fun List<LocationDtoOut>.sorted() = map { it.withSortedSlots() }
+
+    private fun LocationDtoOut.withSortedSlots() = copy(slots = slots.sortedBy { it.from })
+
+//    private fun <T> Op<Boolean>.andWithIfNotEmpty(value: T?, column: Column<T>): Op<Boolean> =
+//        value?.let { and { column eq value } } ?: this
+}

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/setup/DependencyInjection.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/setup/DependencyInjection.kt
@@ -1,16 +1,19 @@
 package blue.mild.covid.vaxx.setup
 
 import blue.mild.covid.vaxx.dao.repository.DataCorrectnessRepository
+import blue.mild.covid.vaxx.dao.repository.LocationRepository
 import blue.mild.covid.vaxx.dao.repository.NurseRepository
 import blue.mild.covid.vaxx.dao.repository.PatientRepository
 import blue.mild.covid.vaxx.dao.repository.UserRepository
 import blue.mild.covid.vaxx.dao.repository.VaccinationRepository
+import blue.mild.covid.vaxx.dao.repository.VaccinationSlotRepository
 import blue.mild.covid.vaxx.dto.config.DatabaseConfigurationDto
 import blue.mild.covid.vaxx.dto.config.MailJetConfigurationDto
 import blue.mild.covid.vaxx.security.ddos.CaptchaVerificationService
 import blue.mild.covid.vaxx.security.ddos.RequestVerificationService
 import blue.mild.covid.vaxx.service.DataCorrectnessService
 import blue.mild.covid.vaxx.service.IsinRegistrationService
+import blue.mild.covid.vaxx.service.LocationService
 import blue.mild.covid.vaxx.service.MailJetEmailService
 import blue.mild.covid.vaxx.service.MailService
 import blue.mild.covid.vaxx.service.MedicalRegistrationService
@@ -67,6 +70,8 @@ fun DI.MainBuilder.registerClasses() {
         }
     }
 
+    bind<LocationRepository>() with singleton { LocationRepository() }
+    bind<VaccinationSlotRepository>() with singleton { VaccinationSlotRepository() }
     bind<PatientRepository>() with singleton { PatientRepository(instance()) }
     bind<UserRepository>() with singleton { UserRepository() }
     bind<DataCorrectnessRepository>() with singleton { DataCorrectnessRepository() }
@@ -78,6 +83,7 @@ fun DI.MainBuilder.registerClasses() {
 
     bind<QuestionService>() with singleton { QuestionService() }
     bind<ValidationService>() with singleton { ValidationService(instance()) }
+    bind<LocationService>() with singleton { LocationService(instance()) }
     bind<PatientService>() with singleton { PatientService(instance(), instance()) }
     bind<UserService>() with singleton { UserService(instance(), instance()) }
     bind<VaccinationService>() with singleton { VaccinationService(instance()) }

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/setup/DependencyInjection.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/setup/DependencyInjection.kt
@@ -23,6 +23,7 @@ import blue.mild.covid.vaxx.service.QuestionService
 import blue.mild.covid.vaxx.service.SystemStatisticsService
 import blue.mild.covid.vaxx.service.UserService
 import blue.mild.covid.vaxx.service.VaccinationService
+import blue.mild.covid.vaxx.service.VaccinationSlotService
 import blue.mild.covid.vaxx.service.ValidationService
 import blue.mild.covid.vaxx.service.dummy.DummyMailService
 import blue.mild.covid.vaxx.service.dummy.DummyMedicalRegistrationService
@@ -84,6 +85,7 @@ fun DI.MainBuilder.registerClasses() {
     bind<QuestionService>() with singleton { QuestionService() }
     bind<ValidationService>() with singleton { ValidationService(instance()) }
     bind<LocationService>() with singleton { LocationService(instance()) }
+    bind<VaccinationSlotService>() with singleton { VaccinationSlotService(instance(), instance()) }
     bind<PatientService>() with singleton { PatientService(instance(), instance()) }
     bind<UserService>() with singleton { UserService(instance(), instance()) }
     bind<VaccinationService>() with singleton { VaccinationService(instance()) }

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/setup/KtorInstallation.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/setup/KtorInstallation.kt
@@ -59,7 +59,7 @@ import org.kodein.di.instanceOrNull
 import org.kodein.di.ktor.closestDI
 import org.kodein.di.ktor.di
 import org.slf4j.event.Level
-import java.util.UUID
+import java.util.*
 import kotlin.reflect.KType
 
 
@@ -83,13 +83,24 @@ fun Application.init() {
  */
 fun Application.setupDiAwareApplication() {
     // now kodein is running and can be used
-    installationLogger.debug { "DI container started." }
+    installationLogger.debug { "DI container - setupDiAwareApplication - BEGIN." }
+
     // connect to the database
+    installationLogger.debug { "DI container - connecting to DB - BEGIN." }
     connectDatabase()
+    installationLogger.debug { "DI container - connecting to DB - END." }
+
     // configure Ktor
+    installationLogger.debug { "DI container - installing frameworks - BEGIN." }
     installFrameworks()
+    installationLogger.debug { "DI container - installing frameworks - END." }
+
     // configure routing
+    installationLogger.debug { "DI container - installing routes - BEGIN." }
     installRouting()
+    installationLogger.debug { "DI container - installing routes - END." }
+
+    installationLogger.debug { "DI container - setupDiAwareApplication - END." }
 }
 
 private fun Application.installRouting() {
@@ -136,10 +147,13 @@ private fun Application.connectDatabase() {
 private fun Application.migrateDatabase() {
     installationLogger.info { "Migrating database." }
     val shouldMigrate by closestDI().instanceOrNull<Boolean>("should-migrate")
+    installationLogger.info { "Migrating database - should migrate: ${shouldMigrate}." }
     // enable migration by default
     if (shouldMigrate != false) {
         val flyway by closestDI().instance<Flyway>()
+        installationLogger.info { "Migrating database - migration - BEGIN." }
         val migrateResult = flyway.migrate()
+        installationLogger.info { "Migrating database - migration - END." }
 
         installationLogger.info {
             if (migrateResult.migrationsExecuted == 0) "No migrations necessary."

--- a/backend/src/main/resources/db/migration/V4__add_location_scheme.sql
+++ b/backend/src/main/resources/db/migration/V4__add_location_scheme.sql
@@ -32,9 +32,10 @@ CREATE TABLE vaccination_slots
     updated              TIMESTAMPTZ      NOT NULL,
     location_id          UUID             NOT NULL REFERENCES locations (id) ON DELETE CASCADE,
     patient_id           UUID             REFERENCES patients (id) ON DELETE SET NULL,
+    queue                INTEGER          NOT NULL,
     "from"               TIMESTAMPTZ      NOT NULL,
     "to"                 TIMESTAMPTZ      NOT NULL,
-    UNIQUE(location_id, "from", "to")
+    UNIQUE(location_id, queue, "from", "to")
 );
 
 CREATE TRIGGER tgr_vaccination_slots_set_created

--- a/backend/src/main/resources/db/migration/V4__add_location_scheme.sql
+++ b/backend/src/main/resources/db/migration/V4__add_location_scheme.sql
@@ -30,10 +30,11 @@ CREATE TABLE vaccination_slots
     id                   UUID PRIMARY KEY NOT NULL DEFAULT uuid_generate_v4(),
     created              TIMESTAMPTZ      NOT NULL,
     updated              TIMESTAMPTZ      NOT NULL,
-    location_id          UUID UNIQUE      NOT NULL REFERENCES locations (id) ON DELETE CASCADE,
-    patient_id           UUID UNIQUE      REFERENCES patients (id) ON DELETE SET NULL,
+    location_id          UUID             NOT NULL REFERENCES locations (id) ON DELETE CASCADE,
+    patient_id           UUID             REFERENCES patients (id) ON DELETE SET NULL,
     "from"               TIMESTAMPTZ      NOT NULL,
-    "to"                 TIMESTAMPTZ      NOT NULL
+    "to"                 TIMESTAMPTZ      NOT NULL,
+    UNIQUE(location_id, "from", "to")
 );
 
 CREATE TRIGGER tgr_vaccination_slots_set_created

--- a/backend/src/main/resources/db/migration/V4__add_location_scheme.sql
+++ b/backend/src/main/resources/db/migration/V4__add_location_scheme.sql
@@ -1,0 +1,49 @@
+-- Create table locations
+CREATE TABLE locations
+(
+    id                UUID PRIMARY KEY   NOT NULL DEFAULT uuid_generate_v4(),
+    created           TIMESTAMPTZ        NOT NULL,
+    updated           TIMESTAMPTZ        NOT NULL,
+    address           VARCHAR(256)       NOT NULL,
+    zip_code          INTEGER            NOT NULL,
+    district          VARCHAR(128)       NOT NULL,
+    phone_number      VARCHAR(13)        NOT NULL,
+    email             VARCHAR(256)       NOT NULL,
+    notes             TEXT
+);
+
+CREATE TRIGGER tgr_locations_set_created
+    BEFORE INSERT
+    ON locations
+    FOR EACH ROW
+EXECUTE PROCEDURE set_created();
+
+CREATE TRIGGER tgr_locations_set_updated
+    BEFORE UPDATE
+    ON locations
+    FOR EACH ROW
+EXECUTE PROCEDURE set_updated();
+
+-- Create vaccination slots table
+CREATE TABLE vaccination_slots
+(
+    id                   UUID PRIMARY KEY NOT NULL DEFAULT uuid_generate_v4(),
+    created              TIMESTAMPTZ      NOT NULL,
+    updated              TIMESTAMPTZ      NOT NULL,
+    location_id          UUID UNIQUE      NOT NULL REFERENCES locations (id) ON DELETE CASCADE,
+    patient_id           UUID UNIQUE      REFERENCES patients (id) ON DELETE SET NULL,
+    "from"               TIMESTAMPTZ      NOT NULL,
+    "to"                 TIMESTAMPTZ      NOT NULL
+);
+
+CREATE TRIGGER tgr_vaccination_slots_set_created
+    BEFORE INSERT
+    ON vaccination_slots
+    FOR EACH ROW
+EXECUTE PROCEDURE set_created();
+
+CREATE TRIGGER tgr_vaccination_slots_set_updated
+    BEFORE UPDATE
+    ON vaccination_slots
+    FOR EACH ROW
+EXECUTE PROCEDURE set_updated();

--- a/backend/src/main/resources/db/migration/V4__add_location_scheme.sql
+++ b/backend/src/main/resources/db/migration/V4__add_location_scheme.sql
@@ -32,10 +32,10 @@ CREATE TABLE vaccination_slots
     updated              TIMESTAMPTZ      NOT NULL,
     location_id          UUID             NOT NULL REFERENCES locations (id) ON DELETE CASCADE,
     patient_id           UUID             REFERENCES patients (id) ON DELETE SET NULL,
-    queue                INTEGER          NOT NULL,
+    "queue"              INTEGER          NOT NULL,
     "from"               TIMESTAMPTZ      NOT NULL,
     "to"                 TIMESTAMPTZ      NOT NULL,
-    UNIQUE(location_id, queue, "from", "to")
+    UNIQUE(location_id, "queue", "from", "to")
 );
 
 CREATE TRIGGER tgr_vaccination_slots_set_created

--- a/backend/src/test/kotlin/blue/mild/covid/vaxx/routes/LocationRoutesTest.kt
+++ b/backend/src/test/kotlin/blue/mild/covid/vaxx/routes/LocationRoutesTest.kt
@@ -10,7 +10,6 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.testing.handleRequest
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 
 
 class LocationRoutesTest : ServerTestBase() {
@@ -30,9 +29,9 @@ class LocationRoutesTest : ServerTestBase() {
             jsonBody(location)
         }.run {
             expectStatus(HttpStatusCode.OK)
-            val response = receive<EntityId>()
+            val responseP = receive<EntityId>()
 
-            handleRequest(HttpMethod.Post, Routes.locations + "/${response}") {
+            handleRequest(HttpMethod.Post, Routes.locations + "/${responseP}") {
                 authorize()
             }.run {
                 expectStatus(HttpStatusCode.OK)
@@ -43,7 +42,7 @@ class LocationRoutesTest : ServerTestBase() {
                 assertEquals(location.phoneNumber?.toString(), response.phoneNumber)
                 assertEquals(location.email, response.email)
                 assertEquals(location.note, response.note)
-                assertNotNull(response.id)
+                assertEquals(responseP, response.id)
             }
 
 

--- a/backend/src/test/kotlin/blue/mild/covid/vaxx/routes/LocationRoutesTest.kt
+++ b/backend/src/test/kotlin/blue/mild/covid/vaxx/routes/LocationRoutesTest.kt
@@ -1,7 +1,6 @@
 package blue.mild.covid.vaxx.routes
 
 import blue.mild.covid.vaxx.dao.model.EntityId
-import blue.mild.covid.vaxx.dto.request.CreateVaccinationSlotsDtoIn
 import blue.mild.covid.vaxx.dto.request.LocationDtoIn
 import blue.mild.covid.vaxx.dto.request.PhoneNumberDtoIn
 import blue.mild.covid.vaxx.dto.response.LocationDtoOut
@@ -10,7 +9,6 @@ import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.testing.handleRequest
 import org.junit.jupiter.api.Test
-import java.time.Instant
 import kotlin.test.assertEquals
 
 
@@ -48,18 +46,20 @@ class LocationRoutesTest : ServerTestBase() {
                 assertEquals(locationId, response.id)
             }
 
-            val createSlots = CreateVaccinationSlotsDtoIn(
-                from = Instant.ofEpochSecond(1000),
-                to = Instant.ofEpochSecond(2000),
-                durationSec = 100
-            )
-
-            handleRequest(HttpMethod.Post, Routes.locations + "/${locationId}/slots") {
-                authorize()
-                jsonBody(createSlots)
-            }.run {
-                expectStatus(HttpStatusCode.OK)
-            }
+            // MartinLLama - Locations: I am not able to figure out how to configure /locations/{id}/slots
+//            val createSlots = CreateVaccinationSlotsDtoIn(
+//                from = Instant.ofEpochSecond(1000),
+//                to = Instant.ofEpochSecond(2000),
+//                durationSec = 100,
+//            )
+//            handleRequest(HttpMethod.Post, Routes.locations + "/${locationId}/slots") {
+//                authorize()
+//                jsonBody(createSlots)
+//            }.run {
+//                expectStatus(HttpStatusCode.OK)
+//                val response = receive<List<EntityId>>()
+//                assertEquals(10, response.size)
+//            }
         }
     }
 }

--- a/backend/src/test/kotlin/blue/mild/covid/vaxx/routes/LocationRoutesTest.kt
+++ b/backend/src/test/kotlin/blue/mild/covid/vaxx/routes/LocationRoutesTest.kt
@@ -20,9 +20,9 @@ class LocationRoutesTest : ServerTestBase() {
             address = "Foo Street 1",
             zipCode = 16000,
             district = "Dejvice",
-            phoneNumber = PhoneNumberDtoIn("724123456", "CZ"),
+            phoneNumber = PhoneNumberDtoIn("+420724123456", "CZ"),
             email = "location-1@test.com",
-            note = "location-1 - note"
+            notes = "location-1 - note"
         )
         handleRequest(HttpMethod.Post, Routes.locations) {
             authorize()
@@ -31,7 +31,7 @@ class LocationRoutesTest : ServerTestBase() {
             expectStatus(HttpStatusCode.OK)
             val responseP = receive<EntityId>()
 
-            handleRequest(HttpMethod.Post, Routes.locations + "/${responseP}") {
+            handleRequest(HttpMethod.Get, Routes.locations + "/${responseP}") {
                 authorize()
             }.run {
                 expectStatus(HttpStatusCode.OK)
@@ -39,9 +39,10 @@ class LocationRoutesTest : ServerTestBase() {
                 assertEquals(location.address, response.address)
                 assertEquals(location.zipCode, response.zipCode)
                 assertEquals(location.district, response.district)
-                assertEquals(location.phoneNumber?.toString(), response.phoneNumber)
+                // MartinLlama: Figure out how to compare phone numbers
+                assertEquals(location.phoneNumber?.number, response.phoneNumber)
                 assertEquals(location.email, response.email)
-                assertEquals(location.note, response.note)
+                assertEquals(location.notes, response.notes)
                 assertEquals(responseP, response.id)
             }
 

--- a/backend/src/test/kotlin/blue/mild/covid/vaxx/routes/LocationRoutesTest.kt
+++ b/backend/src/test/kotlin/blue/mild/covid/vaxx/routes/LocationRoutesTest.kt
@@ -1,0 +1,52 @@
+package blue.mild.covid.vaxx.routes
+
+import blue.mild.covid.vaxx.dao.model.EntityId
+import blue.mild.covid.vaxx.dto.request.LocationDtoIn
+import blue.mild.covid.vaxx.dto.request.PhoneNumberDtoIn
+import blue.mild.covid.vaxx.dto.response.LocationDtoOut
+import blue.mild.covid.vaxx.utils.ServerTestBase
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.handleRequest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+
+class LocationRoutesTest : ServerTestBase() {
+    @Test
+    fun `add location`() = withTestApplication {
+        // try to login with non-existing user
+        val location = LocationDtoIn(
+            address = "Foo Street 1",
+            zipCode = 16000,
+            district = "Dejvice",
+            phoneNumber = PhoneNumberDtoIn("724123456", "CZ"),
+            email = "location-1@test.com",
+            note = "location-1 - note"
+        )
+        handleRequest(HttpMethod.Post, Routes.locations) {
+            authorize()
+            jsonBody(location)
+        }.run {
+            expectStatus(HttpStatusCode.OK)
+            val response = receive<EntityId>()
+
+            handleRequest(HttpMethod.Post, Routes.locations + "/${response}") {
+                authorize()
+            }.run {
+                expectStatus(HttpStatusCode.OK)
+                val response = receive<LocationDtoOut>()
+                assertEquals(location.address, response.address)
+                assertEquals(location.zipCode, response.zipCode)
+                assertEquals(location.district, response.district)
+                assertEquals(location.phoneNumber?.toString(), response.phoneNumber)
+                assertEquals(location.email, response.email)
+                assertEquals(location.note, response.note)
+                assertNotNull(response.id)
+            }
+
+
+        }
+    }
+}

--- a/backend/src/test/kotlin/blue/mild/covid/vaxx/routes/LocationRoutesTest.kt
+++ b/backend/src/test/kotlin/blue/mild/covid/vaxx/routes/LocationRoutesTest.kt
@@ -1,6 +1,7 @@
 package blue.mild.covid.vaxx.routes
 
 import blue.mild.covid.vaxx.dao.model.EntityId
+import blue.mild.covid.vaxx.dto.request.CreateVaccinationSlotsDtoIn
 import blue.mild.covid.vaxx.dto.request.LocationDtoIn
 import blue.mild.covid.vaxx.dto.request.PhoneNumberDtoIn
 import blue.mild.covid.vaxx.dto.response.LocationDtoOut
@@ -9,6 +10,7 @@ import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.testing.handleRequest
 import org.junit.jupiter.api.Test
+import java.time.Instant
 import kotlin.test.assertEquals
 
 
@@ -29,9 +31,9 @@ class LocationRoutesTest : ServerTestBase() {
             jsonBody(location)
         }.run {
             expectStatus(HttpStatusCode.OK)
-            val responseP = receive<EntityId>()
+            val locationId = receive<EntityId>()
 
-            handleRequest(HttpMethod.Get, Routes.locations + "/${responseP}") {
+            handleRequest(HttpMethod.Get, Routes.locations + "/${locationId}") {
                 authorize()
             }.run {
                 expectStatus(HttpStatusCode.OK)
@@ -43,10 +45,21 @@ class LocationRoutesTest : ServerTestBase() {
                 assertEquals(location.phoneNumber?.number, response.phoneNumber)
                 assertEquals(location.email, response.email)
                 assertEquals(location.notes, response.notes)
-                assertEquals(responseP, response.id)
+                assertEquals(locationId, response.id)
             }
 
+            val createSlots = CreateVaccinationSlotsDtoIn(
+                from = Instant.ofEpochSecond(1000),
+                to = Instant.ofEpochSecond(2000),
+                durationSec = 100
+            )
 
+            handleRequest(HttpMethod.Post, Routes.locations + "/${locationId}/slots") {
+                authorize()
+                jsonBody(createSlots)
+            }.run {
+                expectStatus(HttpStatusCode.OK)
+            }
         }
     }
 }

--- a/backend/src/test/kotlin/blue/mild/covid/vaxx/routes/VaccinationSlotRoutesTest.kt
+++ b/backend/src/test/kotlin/blue/mild/covid/vaxx/routes/VaccinationSlotRoutesTest.kt
@@ -1,0 +1,72 @@
+package blue.mild.covid.vaxx.routes
+
+import blue.mild.covid.vaxx.dao.model.EntityId
+import blue.mild.covid.vaxx.dto.request.CreateVaccinationSlotsDtoIn
+import blue.mild.covid.vaxx.dto.request.LocationDtoIn
+import blue.mild.covid.vaxx.dto.request.PhoneNumberDtoIn
+import blue.mild.covid.vaxx.service.LocationService
+import blue.mild.covid.vaxx.service.VaccinationSlotService
+import blue.mild.covid.vaxx.utils.ServerTestBase
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.handleRequest
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.kodein.di.instance
+import java.time.Instant
+import java.util.*
+import kotlin.test.assertEquals
+
+
+class VaccinationSlotRoutesTest : ServerTestBase() {
+    @Test
+    fun `add slots for not-existing location should fail`() = withTestApplication {
+        val createSlots = CreateVaccinationSlotsDtoIn(
+            locationId = UUID.randomUUID(),
+            from = Instant.ofEpochSecond(1000),
+            to = Instant.ofEpochSecond(2000),
+            durationSec = 100
+        )
+        handleRequest(HttpMethod.Post, Routes.vaccinationSlots) {
+            authorize()
+            jsonBody(createSlots)
+        }.run {
+            expectStatus(HttpStatusCode.NotFound)
+        }
+    }
+
+    @Test
+    fun `foo bar`() = withTestApplication {
+        val locationService by closestDI().instance<LocationService>()
+        val vaccinationSlotService by closestDI().instance<VaccinationSlotService>()
+
+        // prepare location
+        val location = LocationDtoIn(
+            address = "Foo Street 1",
+            zipCode = 16000,
+            district = "Dejvice",
+            phoneNumber = PhoneNumberDtoIn("+420724123456", "CZ"),
+            email = "location-1@test.com",
+            notes = "location-1 - note"
+        )
+        val locationId = runBlocking { locationService.addLocation(location) }
+
+        // prepare slot
+        val createSlots = CreateVaccinationSlotsDtoIn(
+            locationId = locationId,
+            from = Instant.ofEpochSecond(1000),
+            to = Instant.ofEpochSecond(2000),
+            durationSec = 100,
+        )
+
+        handleRequest(HttpMethod.Post, Routes.vaccinationSlots) {
+            authorize()
+            jsonBody(createSlots)
+        }.run {
+            expectStatus(HttpStatusCode.OK)
+            val slots = receive<List<EntityId>>()
+            assertEquals(10, slots.size)
+        }
+
+    }
+}

--- a/backend/src/test/kotlin/blue/mild/covid/vaxx/routes/VaccinationSlotRoutesTest.kt
+++ b/backend/src/test/kotlin/blue/mild/covid/vaxx/routes/VaccinationSlotRoutesTest.kt
@@ -257,6 +257,15 @@ class VaccinationSlotRoutesTest : ServerTestBase() {
             assertEquals(2, slots.size)
         }
 
+        // get slots - ALL with given patient
+        handleRequest(HttpMethod.Get, "${Routes.vaccinationSlots}/filter?status=${VaccinationSlotStatus.ALL}&patientId=${patientId}") {
+            authorize()
+        }.run {
+            expectStatus(HttpStatusCode.OK)
+            val slots = receive<List<VaccinationSlotDtoOut>>()
+            assertEquals(2, slots.size)
+        }
+
         // get occopied slots
         val slotsOccupied  = runBlocking { vaccinationSlotService.getSlotsByConjunctionOf(status = VaccinationSlotStatus.ONLY_OCCUPIED) }
         val firstOccupiedId = slotsOccupied[0].id


### PR DESCRIPTION
# Task :notebook: 

Prepare API that will allow creation of location where vaccination could happen, specification of opening hours with additional information how many people could be vaccinated in parallel and how long it takes.

# Solution :hammer_and_wrench: 

I am not able to create proper RESTFul API, see `MartinLLama` comments in the `LocationRoutes`, therefore I am creating this strangely looking API. :/

There are following endpoints:

## Locations  ##

* `POST` - `/admin/locations/` - `{"address": "Address", "zipCode": 16000, "district": "Dejvice", "phoneNumber": "1234", "email": "location-1@test.com", "notes": "note"}` - that creates location with given attributes. This API call returns id of the newly created location.
* `GET` - `/admin/locations/{locationId}` - returns location with `locationId`

See `LocationRoutesTest` for more details.

## Vaccination Spots ##

* `POST` - `/admin/vaccination-slots/` - `{"locationId": locationId, "from": "when location opens", "to": "when location closes", "durationMillis": "how many miliseconds it takes to vaccinate single person", "bandwidth": "How many people can be vaccinated in parallel."}`
  * So request like `{"locationId": 1, "from": "2021-05-28 14:00:00", "to": "2021-05-28 22:00:00", "durationMillis": 30 * 60 * 1000, "bandwidth": 4}` - creates 64 (8 hours * 2 per hour * 4 people in parallel) vaccination slots.
* `GET` - `/admin/vaccination-slots/filters?id=...&locationId=...&fromMillis=...&toMillis=...&status=...` - returns vaccination slots with given status.
  * `id` - vaccination slot id, `locationId` - location id, `fromMillis` - `from` attribute has to be greater or equal than this, `toMillis` - `to` attribute has to be smaller or equal than this, `status` - if all, only free, or only occupied slots should be returned
* `POST` - `/admin/vaccination-slots/filters?id=...&locationId=...&fromMillis=...&toMillis=...&status=...` - `{"patientId": ...}` - assigns given patient (or frees the slot if patientId is `null`) to the first slot that would be returned by the corresponding `GET` API call

See `VaccinationSlotRoutesTest` for more details.

# Testing :school: 

* Run tests - `make test`
* Run detekt - `make detekt`

I am not able to call those endpoints since the application does not start. `make run` produces - `Exception in thread "main" io.ktor.application.DuplicateApplicationFeatureException: Conflicting application feature is already installed with the same key as [Global DI Container]`

# Meta

Related to issue: #211 