### PR TITLE
Add numeric code to insurance company

### DIFF
--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/response/InsuranceCompanyDetailsDtoOut.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/response/InsuranceCompanyDetailsDtoOut.kt
@@ -5,9 +5,10 @@ import blue.mild.covid.vaxx.dao.model.InsuranceCompany
 data class InsuranceCompanyDetailsDtoOut(
     val name: String,
     val csFullName: String,
-    val code: InsuranceCompany
+    val code: InsuranceCompany,
+    val numericCode: Int
 ) {
     constructor(company: InsuranceCompany) : this(
-        name = company.name, csFullName = company.csFullName, code = company
+        name = company.name, csFullName = company.csFullName, code = company, numericCode = company.code
     )
 }


### PR DESCRIPTION
* closes #264 

je to vlastne takove vtipne, protoze serializujeme enumy jako stringy, takze frontend predtim nikdy nedostal ten kod ackoliv o nem BE vzdy vi