### PR TITLE
Add insurance number unique constraint

### DIFF
--- a/backend/src/main/resources/db/migration/V8__insurance_number_unique.sql
+++ b/backend/src/main/resources/db/migration/V8__insurance_number_unique.sql
@@ -1,0 +1,3 @@
+-- add insurance number unique constraint
+ALTER TABLE patients
+    ADD UNIQUE (insurance_number);


### PR DESCRIPTION
Otestoval jsem provoláváním api callů.

Migrace vyhodí problémy, pokud constraint splněný nebude, před migrací zkusit provolat

```
SELECT insurance_number FROM patients
WHERE insurance_number IS NOT NULL
GROUP BY insurance_number
HAVING count(*) > 1;
```