### PR TITLE
Api na validaci a export v ISIN

### DIFF
--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/repository/DataCorrectnessRepository.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/repository/DataCorrectnessRepository.kt
@@ -89,4 +89,30 @@ class DataCorrectnessRepository {
                 }
         }
 
+
+    /**
+     * Updates correctness entity with id [correctnessId].
+     */
+    suspend fun updateCorrectness(
+        correctnessId: EntityId,
+        notes: String? = null,
+        exportedToIsinOn: Instant? = null
+    ): Boolean = newSuspendedTransaction {
+        val isUpdateNecessary =
+            notes ?: exportedToIsinOn
+
+        // if so, perform update query
+        val correctnessUpdated = if (isUpdateNecessary != null) {
+            PatientDataCorrectnessConfirmation.update(
+                where = { PatientDataCorrectnessConfirmation.id eq correctnessId },
+                body = { row ->
+                    row.apply {
+                        updateIfNotNull(notes, PatientDataCorrectnessConfirmation.notes)
+                        updateIfNotNull(exportedToIsinOn, PatientDataCorrectnessConfirmation.exportedToIsinOn)
+                    }
+                }
+            )
+        } else 0
+        correctnessUpdated == 1
+    }
 }

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/repository/PatientRepository.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dao/repository/PatientRepository.kt
@@ -104,10 +104,10 @@ class PatientRepository(
      * If no clause is given, it returns and maps whole database.
      */
     suspend fun getAndMapPatientsBy(
-        where: (SqlExpressionBuilder.() -> Op<Boolean>)? = null,
         n: Int? = null,
-        offset: Long = 0
-    ): List<PatientDtoOut> = newSuspendedTransaction { getAndMapPatients(where, n, offset) }
+        offset: Long = 0,
+        where: (SqlExpressionBuilder.() -> Op<Boolean>)? = null
+    ): List<PatientDtoOut> = newSuspendedTransaction { getAndMapPatients(n, offset, where) }
 
     /**
      * Gets and maps patient by given ID.
@@ -115,7 +115,7 @@ class PatientRepository(
      * Returns null if no patient was found.
      */
     suspend fun getAndMapById(patientId: EntityId): PatientDtoOut? =
-        getAndMapPatientsBy( { Patients.id eq patientId } ).singleOrNull()
+        getAndMapPatientsBy { Patients.id eq patientId }.singleOrNull()
 
 
     /**
@@ -180,7 +180,7 @@ class PatientRepository(
         newSuspendedTransaction { Patients.deleteWhere(op = where) }
 
 
-    private fun getAndMapPatients(where: (SqlExpressionBuilder.() -> Op<Boolean>)? = null, n: Int? = null, offset: Long = 0) =
+    private fun getAndMapPatients(n: Int? = null, offset: Long = 0, where: (SqlExpressionBuilder.() -> Op<Boolean>)? = null) =
         Patients
             .leftJoin(Answers, { id }, { patientId })
             .leftJoin(Vaccinations, { Patients.vaccination }, { id })

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/IsinJobDtoIn.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/IsinJobDtoIn.kt
@@ -1,0 +1,10 @@
+package blue.mild.covid.vaxx.dto.request
+
+data class IsinJobDtoIn(
+    val validatePatients: Boolean = false,
+    val exportPatientsInfo: Boolean = false,
+    val exportVaccinations: Boolean = false,
+
+    val patientsOffset: Int = 0,
+    val patientsCount: Int? = null
+)

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/PatientRegistrationDtoIn.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/request/PatientRegistrationDtoIn.kt
@@ -3,12 +3,18 @@ package blue.mild.covid.vaxx.dto.request
 import blue.mild.covid.vaxx.dao.model.InsuranceCompany
 
 
+interface PatientBasicInfoDto {
+    val firstName: String
+    val lastName: String
+    val personalNumber: String?
+}
+
 data class PatientRegistrationDtoIn(
-    val firstName: String,
-    val lastName: String,
+    override val firstName: String,
+    override val lastName: String,
     val zipCode: Int,
     val district: String,
-    val personalNumber: String?,
+    override val personalNumber: String?,
     val insuranceNumber: String?,
     val phoneNumber: PhoneNumberDtoIn,
     val email: String,
@@ -16,4 +22,4 @@ data class PatientRegistrationDtoIn(
     val indication: String? = null,
     val answers: List<AnswerDtoIn>,
     val confirmation: ConfirmationDtoIn
-)
+): PatientBasicInfoDto

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/response/DataCorrectnessConfirmationDtoOut.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/response/DataCorrectnessConfirmationDtoOut.kt
@@ -1,8 +1,11 @@
 package blue.mild.covid.vaxx.dto.response
 
 import blue.mild.covid.vaxx.dao.model.EntityId
+import java.time.Instant
 
 data class DataCorrectnessConfirmationDtoOut(
     val id: EntityId,
-    val dataAreCorrect: Boolean
+    val dataAreCorrect: Boolean,
+    val exportedToIsinOn: Instant?,
+    val notes: String?
 )

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/response/IsinJobDtoOut.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/response/IsinJobDtoOut.kt
@@ -1,0 +1,12 @@
+package blue.mild.covid.vaxx.dto.response
+
+data class IsinJobDtoOut(
+    var validatedPatientsSuccess: Int = 0,
+    var validatedPatientsErrors: Int = 0,
+
+    var exportedPatientsInfoSuccess: Int = 0,
+    var exportedPatientsInfoErrors: Int = 0,
+
+    var exportedVaccinationsSuccess: Int = 0,
+    var exportedVaccinationsErrors: Int = 0
+)

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/response/IsinJobDtoOut.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/response/IsinJobDtoOut.kt
@@ -1,12 +1,12 @@
 package blue.mild.covid.vaxx.dto.response
 
 data class IsinJobDtoOut(
-    var validatedPatientsSuccess: Int = 0,
-    var validatedPatientsErrors: Int = 0,
+    val validatedPatientsSuccess: Int,
+    val validatedPatientsErrors: Int,
 
-    var exportedPatientsInfoSuccess: Int = 0,
-    var exportedPatientsInfoErrors: Int = 0,
+    val exportedPatientsInfoSuccess: Int,
+    val exportedPatientsInfoErrors: Int,
 
-    var exportedVaccinationsSuccess: Int = 0,
-    var exportedVaccinationsErrors: Int = 0
+    val exportedVaccinationsSuccess: Int,
+    val exportedVaccinationsErrors: Int
 )

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/response/VaccinationDtoOut.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/dto/response/VaccinationDtoOut.kt
@@ -5,5 +5,7 @@ import java.time.Instant
 
 data class VaccinationDtoOut(
     val id: EntityId,
-    val vaccinatedOn: Instant
+    val vaccinatedOn: Instant,
+    val exportedToIsinOn: Instant?,
+    val notes: String?
 )

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/PatientRoutes.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/PatientRoutes.kt
@@ -68,7 +68,11 @@ fun NormalOpenAPIRoute.patientRoutes() {
             val patientIsinId: String? = if (patientRegistration.personalNumber != null) {
                 logger.info { "Validating patient in the ISIN." }
                 // TODO  maybe validate received input before actually using ISIN
-                val patientValidationResult = patientValidation.validatePatient(patientRegistration)
+                val patientValidationResult = patientValidation.validatePatient(
+                    patientRegistration.firstName,
+                    patientRegistration.lastName,
+                    patientRegistration.personalNumber
+                )
                 logger.info { "Validation completed." }
 
                 when (patientValidationResult.status) {

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/Routes.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/Routes.kt
@@ -15,6 +15,7 @@ object Routes {
     val statusHealth = "$status/health"
 
     val systemStatistics = adminRoute("statistics")
+    val runIsinJob = adminRoute("run-isin-job")
 
     val registeredUserLogin = adminRoute("login")
     val userRegistration = adminRoute("register")

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/ServiceRoutes.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/ServiceRoutes.kt
@@ -31,8 +31,6 @@ import org.kodein.di.instance
 /**
  * Registers prometheus data.
  */
-// TODO move functionality somewhere else
-@Suppress("LongMethod", "ComplexMethod")
 fun NormalOpenAPIRoute.serviceRoutes() {
     val version by closestDI().instance<ApplicationInformationDtoOut>()
     val systemStatisticsService by closestDI().instance<SystemStatisticsService>()

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/ServiceRoutes.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/ServiceRoutes.kt
@@ -62,7 +62,7 @@ fun NormalOpenAPIRoute.serviceRoutes() {
     authorizeRoute(requireOneOf = setOf(UserRole.ADMIN)) {
         route(Routes.runIsinJob).post<Unit, IsinJobDtoOut, IsinJobDtoIn, UserPrincipal>(
             info(
-                "Checks patients where ISIN was failed and run isin client again."
+                "Checks patients where ISIN has failed and run ISIN client again."
             )
         ) { _, isinJobDto ->
             val principal = principal()

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/ServiceRoutes.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/ServiceRoutes.kt
@@ -2,18 +2,32 @@ package blue.mild.covid.vaxx.routes
 
 import blue.mild.covid.vaxx.dao.model.DatabaseSetup
 import blue.mild.covid.vaxx.dao.model.UserRole
+import blue.mild.covid.vaxx.dao.repository.PatientRepository
+import blue.mild.covid.vaxx.dto.internal.PatientValidationResult
+import blue.mild.covid.vaxx.dto.request.IsinJobDtoIn
 import blue.mild.covid.vaxx.dto.request.query.SystemStatisticsFilterDtoIn
 import blue.mild.covid.vaxx.dto.response.ApplicationInformationDtoOut
+import blue.mild.covid.vaxx.dto.response.IsinJobDtoOut
 import blue.mild.covid.vaxx.dto.response.ServiceHealthDtoOut
 import blue.mild.covid.vaxx.dto.response.SystemStatisticsDtoOut
+import blue.mild.covid.vaxx.dto.response.toPatientVaccinationDetailDto
 import blue.mild.covid.vaxx.extensions.closestDI
+import blue.mild.covid.vaxx.extensions.createLogger
+import blue.mild.covid.vaxx.extensions.determineRealIp
 import blue.mild.covid.vaxx.extensions.request
 import blue.mild.covid.vaxx.extensions.respondWithStatus
 import blue.mild.covid.vaxx.security.auth.UserPrincipal
 import blue.mild.covid.vaxx.security.auth.authorizeRoute
+import blue.mild.covid.vaxx.service.DataCorrectnessService
+import blue.mild.covid.vaxx.service.IsinServiceInterface
+import blue.mild.covid.vaxx.service.PatientService
+import blue.mild.covid.vaxx.service.PatientValidationService
 import blue.mild.covid.vaxx.service.SystemStatisticsService
+import blue.mild.covid.vaxx.service.VaccinationService
 import com.papsign.ktor.openapigen.route.info
 import com.papsign.ktor.openapigen.route.path.auth.get
+import com.papsign.ktor.openapigen.route.path.auth.post
+import com.papsign.ktor.openapigen.route.path.auth.principal
 import com.papsign.ktor.openapigen.route.path.normal.NormalOpenAPIRoute
 import com.papsign.ktor.openapigen.route.path.normal.get
 import com.papsign.ktor.openapigen.route.response.respond
@@ -28,6 +42,14 @@ import org.kodein.di.instance
 fun NormalOpenAPIRoute.serviceRoutes() {
     val version by closestDI().instance<ApplicationInformationDtoOut>()
     val systemStatisticsService by closestDI().instance<SystemStatisticsService>()
+    val patientService by closestDI().instance<PatientService>()
+    val patientValidation by closestDI().instance<PatientValidationService>()
+    val isinService by closestDI().instance<IsinServiceInterface>()
+    val dataCorrectnessService by closestDI().instance<DataCorrectnessService>()
+    val patientRepository by closestDI().instance<PatientRepository>()
+    val vaccinationService by closestDI().instance<VaccinationService>()
+
+    val logger = createLogger("ServiceRoute")
 
     /**
      * Send data about version.
@@ -49,6 +71,108 @@ fun NormalOpenAPIRoute.serviceRoutes() {
     authorizeRoute(requireOneOf = setOf(UserRole.ADMIN)) {
         route(Routes.systemStatistics).get<SystemStatisticsFilterDtoIn, SystemStatisticsDtoOut, UserPrincipal> { query ->
             respond(systemStatisticsService.getSystemStatistics(query))
+        }
+    }
+
+    // TODO move functionality somewhere else
+    authorizeRoute(requireOneOf = setOf(UserRole.ADMIN)) {
+        route(Routes.runIsinJob).post<Unit, IsinJobDtoOut, IsinJobDtoIn, UserPrincipal>(
+            info(
+                "Checks patients where ISIN was failed and run isin client again."
+            )
+        ) { _, isinJobDto ->
+            val principal = principal()
+            logger.info {
+                "Run ISIN job by ${principal.userId} from host ${request.determineRealIp()}."
+            }
+
+            val stats = IsinJobDtoOut()
+
+            val patients = patientService.getPatientsByConjunctionOf(
+                n = isinJobDto.patientsCount,
+                offset = isinJobDto.patientsOffset.toLong()
+            )
+
+            for (patient in patients) {
+                logger.debug("Checking ISIN id of patient ${patient.id}")
+
+                // 1. If patient has personal number but ISIN id is not set -> try ISIN validation
+                val isinId = if (!patient.isinId.isNullOrBlank()) {
+                    patient.isinId
+                } else if (isinJobDto.validatePatients && !patient.personalNumber.isNullOrBlank() ) {
+                    logger.info("Patient ${patient.id} has personal number but no ISIN id. Validating in ISIN...")
+
+                    val patientValidationResult = patientValidation.validatePatient(
+                        firstName = patient.firstName,
+                        lastName = patient.lastName,
+                        personalNumber = patient.personalNumber,
+                    )
+
+                    logger.info {
+                        "Validation of patient ${patient.firstName}/${patient.lastName}/${patient.personalNumber} " +
+                        "completed: status=${patientValidationResult.status}, isinPatientId=${patientValidationResult.patientId}."
+                    }
+
+                    val newIsinPatientId = when (patientValidationResult.status) {
+                        PatientValidationResult.PATIENT_FOUND ->
+                            patientValidationResult.patientId
+                        else -> {
+                            null
+                        }
+                    }
+
+                    if (newIsinPatientId != null) {
+                        logger.debug { "Updating ISIN id of patient ${patient.id} to $newIsinPatientId"}
+                        patientRepository.updatePatientChangeSet(id = patient.id, isinId = newIsinPatientId.trim())
+                        stats.validatedPatientsSuccess++;
+                    } else {
+                        logger.debug { "NOT updating ISIN id of patient ${patient.id}"}
+                        stats.validatedPatientsErrors++;
+                    }
+                    newIsinPatientId
+                } else {
+                    null
+                }
+
+                if (isinId.isNullOrBlank()) continue
+
+                // 2. If data are correct but not exported to ISIN -> try export to isin
+                logger.debug("Checking correctness exported to ISIN of patient ${patient.id}")
+                if (isinJobDto.exportPatientsInfo && patient.dataCorrect != null && patient.dataCorrect.dataAreCorrect && patient.dataCorrect.exportedToIsinOn == null) {
+                    val wasExported = isinService.tryExportPatientContactInfo(patient, notes= patient.dataCorrect.notes)
+
+                    if (wasExported) {
+                        logger.debug { "Updating exported to ISIN of correctness ${patient.dataCorrect.id} (patient ${patient.id})"}
+                        dataCorrectnessService.exportedToIsin(patient.dataCorrect.id)
+                        stats.exportedPatientsInfoSuccess++
+                    } else {
+                        logger.debug { "NOT updating exported to ISIN of correctness ${patient.dataCorrect.id} (patient ${patient.id})"}
+                        stats.exportedPatientsInfoErrors++
+                    }
+                }
+
+                // 3. If vaccinated but not vaccination is not exported to ISIN -> try export vaccination to isin
+                if (isinJobDto.exportVaccinations && patient.vaccinated != null && patient.vaccinated.exportedToIsinOn == null) {
+                    val vaccination = vaccinationService.get(patient.vaccinated.id)
+
+                    // Try to export vaccination to ISIN
+                    val wasExported = isinService.tryCreateVaccinationAndDose(
+                        vaccination.toPatientVaccinationDetailDto(),
+                        patient = patient
+                    )
+
+                    if (wasExported) {
+                        logger.debug { "Updating exported to ISIN of vaccination ${patient.vaccinated.id} (patient ${patient.id})"}
+                        vaccinationService.exportedToIsin(patient.vaccinated.id)
+                        stats.exportedVaccinationsSuccess++
+                    } else {
+                        logger.debug { "NOT updating exported to ISIN of vaccination ${patient.vaccinated.id} (patient ${patient.id})"}
+                        stats.exportedVaccinationsErrors++
+                    }
+                }
+            }
+
+            respond(stats)
         }
     }
 }

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/ServiceRoutes.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/ServiceRoutes.kt
@@ -2,15 +2,12 @@ package blue.mild.covid.vaxx.routes
 
 import blue.mild.covid.vaxx.dao.model.DatabaseSetup
 import blue.mild.covid.vaxx.dao.model.UserRole
-import blue.mild.covid.vaxx.dao.repository.PatientRepository
-import blue.mild.covid.vaxx.dto.internal.PatientValidationResult
 import blue.mild.covid.vaxx.dto.request.IsinJobDtoIn
 import blue.mild.covid.vaxx.dto.request.query.SystemStatisticsFilterDtoIn
 import blue.mild.covid.vaxx.dto.response.ApplicationInformationDtoOut
 import blue.mild.covid.vaxx.dto.response.IsinJobDtoOut
 import blue.mild.covid.vaxx.dto.response.ServiceHealthDtoOut
 import blue.mild.covid.vaxx.dto.response.SystemStatisticsDtoOut
-import blue.mild.covid.vaxx.dto.response.toPatientVaccinationDetailDto
 import blue.mild.covid.vaxx.extensions.closestDI
 import blue.mild.covid.vaxx.extensions.createLogger
 import blue.mild.covid.vaxx.extensions.determineRealIp
@@ -18,14 +15,9 @@ import blue.mild.covid.vaxx.extensions.request
 import blue.mild.covid.vaxx.extensions.respondWithStatus
 import blue.mild.covid.vaxx.security.auth.UserPrincipal
 import blue.mild.covid.vaxx.security.auth.authorizeRoute
-import blue.mild.covid.vaxx.service.DataCorrectnessService
-import blue.mild.covid.vaxx.service.IsinServiceInterface
-import blue.mild.covid.vaxx.service.PatientService
-import blue.mild.covid.vaxx.service.PatientValidationService
+import blue.mild.covid.vaxx.service.IsinRetryService
 import blue.mild.covid.vaxx.service.SystemStatisticsService
-import blue.mild.covid.vaxx.service.VaccinationService
 import com.papsign.ktor.openapigen.route.info
-import com.papsign.ktor.openapigen.route.path.auth.get
 import com.papsign.ktor.openapigen.route.path.auth.post
 import com.papsign.ktor.openapigen.route.path.auth.principal
 import com.papsign.ktor.openapigen.route.path.normal.NormalOpenAPIRoute
@@ -44,12 +36,7 @@ import org.kodein.di.instance
 fun NormalOpenAPIRoute.serviceRoutes() {
     val version by closestDI().instance<ApplicationInformationDtoOut>()
     val systemStatisticsService by closestDI().instance<SystemStatisticsService>()
-    val patientService by closestDI().instance<PatientService>()
-    val patientValidation by closestDI().instance<PatientValidationService>()
-    val isinService by closestDI().instance<IsinServiceInterface>()
-    val dataCorrectnessService by closestDI().instance<DataCorrectnessService>()
-    val patientRepository by closestDI().instance<PatientRepository>()
-    val vaccinationService by closestDI().instance<VaccinationService>()
+    val isinRetryService by closestDI().instance<IsinRetryService>()
 
     val logger = createLogger("ServiceRoute")
 
@@ -74,8 +61,6 @@ fun NormalOpenAPIRoute.serviceRoutes() {
         respond(systemStatisticsService.getSystemStatistics(query))
     }
 
-    // TODO move functionality somewhere else
-    @Suppress("LongMethod", "ComplexCondition", "ComplexMethod")
     authorizeRoute(requireOneOf = setOf(UserRole.ADMIN)) {
         route(Routes.runIsinJob).post<Unit, IsinJobDtoOut, IsinJobDtoIn, UserPrincipal>(
             info(
@@ -87,92 +72,7 @@ fun NormalOpenAPIRoute.serviceRoutes() {
                 "Run ISIN job by ${principal.userId} from host ${request.determineRealIp()}."
             }
 
-            val stats = IsinJobDtoOut()
-
-            val patients = patientService.getPatientsByConjunctionOf(
-                n = isinJobDto.patientsCount,
-                offset = isinJobDto.patientsOffset.toLong()
-            )
-
-            for (patient in patients) {
-                logger.debug("Checking ISIN id of patient ${patient.id}")
-
-                // 1. If patient has personal number but ISIN id is not set -> try ISIN validation
-                val isinId = if (!patient.isinId.isNullOrBlank()) {
-                    patient.isinId
-                } else if (isinJobDto.validatePatients && !patient.personalNumber.isNullOrBlank() ) {
-                    logger.info("Patient ${patient.id} has personal number but no ISIN id. Validating in ISIN...")
-
-                    val patientValidationResult = patientValidation.validatePatient(
-                        firstName = patient.firstName,
-                        lastName = patient.lastName,
-                        personalNumber = patient.personalNumber,
-                    )
-
-                    logger.info {
-                        "Validation of patient ${patient.firstName}/${patient.lastName}/${patient.personalNumber} " +
-                        "completed: status=${patientValidationResult.status}, isinPatientId=${patientValidationResult.patientId}."
-                    }
-
-                    val newIsinPatientId = when (patientValidationResult.status) {
-                        PatientValidationResult.PATIENT_FOUND ->
-                            patientValidationResult.patientId
-                        else -> {
-                            null
-                        }
-                    }
-
-                    if (newIsinPatientId != null) {
-                        logger.debug { "Updating ISIN id of patient ${patient.id} to $newIsinPatientId"}
-                        patientRepository.updatePatientChangeSet(id = patient.id, isinId = newIsinPatientId.trim())
-                        stats.validatedPatientsSuccess++;
-                    } else {
-                        logger.debug { "NOT updating ISIN id of patient ${patient.id}"}
-                        stats.validatedPatientsErrors++;
-                    }
-                    newIsinPatientId
-                } else {
-                    null
-                }
-
-                if (isinId.isNullOrBlank()) continue
-
-                // 2. If data are correct but not exported to ISIN -> try export to isin
-                logger.debug("Checking correctness exported to ISIN of patient ${patient.id}")
-                if (isinJobDto.exportPatientsInfo && patient.dataCorrect != null && patient.dataCorrect.dataAreCorrect &&
-                    patient.dataCorrect.exportedToIsinOn == null) {
-                    val wasExported = isinService.tryExportPatientContactInfo(patient, notes= patient.dataCorrect.notes)
-
-                    if (wasExported) {
-                        logger.debug { "Updating exported to ISIN of correctness ${patient.dataCorrect.id} (patient ${patient.id})"}
-                        dataCorrectnessService.exportedToIsin(patient.dataCorrect.id)
-                        stats.exportedPatientsInfoSuccess++
-                    } else {
-                        logger.debug { "NOT updating exported to ISIN of correctness ${patient.dataCorrect.id} (patient ${patient.id})"}
-                        stats.exportedPatientsInfoErrors++
-                    }
-                }
-
-                // 3. If vaccinated but not vaccination is not exported to ISIN -> try export vaccination to isin
-                if (isinJobDto.exportVaccinations && patient.vaccinated != null && patient.vaccinated.exportedToIsinOn == null) {
-                    val vaccination = vaccinationService.get(patient.vaccinated.id)
-
-                    // Try to export vaccination to ISIN
-                    val wasExported = isinService.tryCreateVaccinationAndDose(
-                        vaccination.toPatientVaccinationDetailDto(),
-                        patient = patient
-                    )
-
-                    if (wasExported) {
-                        logger.debug { "Updating exported to ISIN of vaccination ${patient.vaccinated.id} (patient ${patient.id})"}
-                        vaccinationService.exportedToIsin(patient.vaccinated.id)
-                        stats.exportedVaccinationsSuccess++
-                    } else {
-                        logger.debug { "NOT updating exported to ISIN of vaccination ${patient.vaccinated.id} (patient ${patient.id})"}
-                        stats.exportedVaccinationsErrors++
-                    }
-                }
-            }
+            val stats = isinRetryService.runIsinRetry(isinJobDto)
 
             respond(stats)
         }

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/ServiceRoutes.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/routes/ServiceRoutes.kt
@@ -39,6 +39,8 @@ import org.kodein.di.instance
 /**
  * Registers prometheus data.
  */
+// TODO move functionality somewhere else
+@Suppress("LongMethod", "ComplexMethod")
 fun NormalOpenAPIRoute.serviceRoutes() {
     val version by closestDI().instance<ApplicationInformationDtoOut>()
     val systemStatisticsService by closestDI().instance<SystemStatisticsService>()
@@ -75,6 +77,7 @@ fun NormalOpenAPIRoute.serviceRoutes() {
     }
 
     // TODO move functionality somewhere else
+    @Suppress("LongMethod", "ComplexCondition", "ComplexMethod")
     authorizeRoute(requireOneOf = setOf(UserRole.ADMIN)) {
         route(Routes.runIsinJob).post<Unit, IsinJobDtoOut, IsinJobDtoIn, UserPrincipal>(
             info(
@@ -138,7 +141,8 @@ fun NormalOpenAPIRoute.serviceRoutes() {
 
                 // 2. If data are correct but not exported to ISIN -> try export to isin
                 logger.debug("Checking correctness exported to ISIN of patient ${patient.id}")
-                if (isinJobDto.exportPatientsInfo && patient.dataCorrect != null && patient.dataCorrect.dataAreCorrect && patient.dataCorrect.exportedToIsinOn == null) {
+                if (isinJobDto.exportPatientsInfo && patient.dataCorrect != null && patient.dataCorrect.dataAreCorrect &&
+                    patient.dataCorrect.exportedToIsinOn == null) {
                     val wasExported = isinService.tryExportPatientContactInfo(patient, notes= patient.dataCorrect.notes)
 
                     if (wasExported) {

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/service/DataCorrectnessService.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/service/DataCorrectnessService.kt
@@ -2,12 +2,14 @@ package blue.mild.covid.vaxx.service
 
 import blue.mild.covid.vaxx.dao.model.EntityId
 import blue.mild.covid.vaxx.dao.model.PatientDataCorrectnessConfirmation
+import blue.mild.covid.vaxx.dao.model.Vaccinations
 import blue.mild.covid.vaxx.dao.repository.DataCorrectnessRepository
 import blue.mild.covid.vaxx.dto.internal.ContextAware
 import blue.mild.covid.vaxx.dto.request.DataCorrectnessDtoIn
 import blue.mild.covid.vaxx.dto.response.DataCorrectnessConfirmationDetailDtoOut
 import blue.mild.covid.vaxx.error.entityNotFound
 import pw.forst.katlib.TimeProvider
+import pw.forst.katlib.whenFalse
 import java.time.Instant
 
 class DataCorrectnessService(
@@ -51,5 +53,16 @@ class DataCorrectnessService(
             notes = dataCorrectness.notes?.trim(),
             exportedToIsinOn = exportedToIsinOn
         )
+    }
+
+
+    /**
+     * Register in database that [correctnessId] was exported to ISIN.
+     */
+    suspend fun exportedToIsin(correctnessId: EntityId, storedOn: Instant = instantTimeProvider.now()) {
+        dataCorrectnessRepository.updateCorrectness(
+            correctnessId = correctnessId,
+            exportedToIsinOn = storedOn
+        ).whenFalse { throw entityNotFound<Vaccinations>(PatientDataCorrectnessConfirmation::id, PatientDataCorrectnessConfirmation) }
     }
 }

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/service/IsinRetryService.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/service/IsinRetryService.kt
@@ -88,7 +88,7 @@ class IsinRetryService(
                 }
             }
 
-            // 3. If vaccinated but not vaccination is not exported to ISIN -> try export vaccination to isin
+            // 3. If vaccinated but vaccination is not exported to ISIN -> try export vaccination to ISIN
             if (isinJobDto.exportVaccinations && updatedPatient.vaccinated != null && updatedPatient.vaccinated.exportedToIsinOn == null) {
                 logger.debug("Retrying to create vaccination of patient ${updatedPatient.id} in ISIN")
                 val wasCreated = retryPatientVaccinationCreation(updatedPatient)

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/service/IsinRetryService.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/service/IsinRetryService.kt
@@ -1,0 +1,152 @@
+package blue.mild.covid.vaxx.service
+
+import blue.mild.covid.vaxx.dao.repository.PatientRepository
+import blue.mild.covid.vaxx.dto.internal.PatientValidationResult
+import blue.mild.covid.vaxx.dto.request.IsinJobDtoIn
+import blue.mild.covid.vaxx.dto.response.IsinJobDtoOut
+import blue.mild.covid.vaxx.dto.response.PatientDtoOut
+import blue.mild.covid.vaxx.dto.response.toPatientVaccinationDetailDto
+import mu.KLogging
+
+
+class IsinRetryService(
+    private val patientService: PatientService,
+    private val patientValidation: PatientValidationService,
+    private val isinService: IsinServiceInterface,
+    private val dataCorrectnessService: DataCorrectnessService,
+    private val patientRepository: PatientRepository,
+    private val vaccinationService: VaccinationService,
+) {
+
+    private companion object : KLogging()
+
+    suspend fun runIsinRetry(isinJobDto: IsinJobDtoIn): IsinJobDtoOut {
+        val stats = IsinJobDtoOut()
+
+        val patients = patientService.getPatientsByConjunctionOf(
+            n = isinJobDto.patientsCount,
+            offset = isinJobDto.patientsOffset.toLong()
+        )
+
+        for (patient in patients) {
+            logger.debug("Checking ISIN id of patient ${patient.id}")
+
+            // 1. If patient has personal number but ISIN id is not set -> try ISIN validation
+            val isinId = if (!patient.isinId.isNullOrBlank()) {
+                patient.isinId
+            } else if (isinJobDto.validatePatients && !patient.personalNumber.isNullOrBlank() ) {
+                logger.info("Patient ${patient.id} has personal number but no ISIN id. Validating in ISIN...")
+
+                val newIsinPatientId = retryPatientValidation(patient)
+
+                if (newIsinPatientId != null) {
+                    stats.validatedPatientsSuccess++;
+                } else {
+                    stats.validatedPatientsErrors++;
+                }
+                newIsinPatientId
+            } else {
+                null
+            }
+
+            if (isinId.isNullOrBlank()) continue
+
+            // 2. If data are correct but not exported to ISIN -> try export to isin
+            logger.debug("Checking correctness exported to ISIN of patient ${patient.id}")
+            if (
+                isinJobDto.exportPatientsInfo &&
+                patient.dataCorrect != null &&
+                patient.dataCorrect.dataAreCorrect &&
+                patient.dataCorrect.exportedToIsinOn == null
+            ) {
+                val wasExported = retryPatientContactInfoExport(patient)
+
+                if (wasExported) {
+                    stats.exportedPatientsInfoSuccess++
+                } else {
+                    stats.exportedPatientsInfoErrors++
+                }
+            }
+
+            // 3. If vaccinated but not vaccination is not exported to ISIN -> try export vaccination to isin
+            if (isinJobDto.exportVaccinations && patient.vaccinated != null && patient.vaccinated.exportedToIsinOn == null) {
+                val wasExported = retryPatientVaccinationCreation(patient)
+
+                if (wasExported) {
+                    stats.exportedVaccinationsSuccess++
+                } else {
+                    stats.exportedVaccinationsErrors++
+                }
+            }
+        }
+
+        return stats
+    }
+
+    private suspend fun retryPatientValidation(patient: PatientDtoOut): String? {
+        val patientValidationResult = patientValidation.validatePatient(
+            firstName = patient.firstName,
+            lastName = patient.lastName,
+            personalNumber = patient.personalNumber ?: throw AssertionError { "Personal number cannot be null."},
+        )
+
+        logger.info {
+            "Validation of patient ${patient.firstName}/${patient.lastName}/${patient.personalNumber} " +
+                    "completed: status=${patientValidationResult.status}, isinPatientId=${patientValidationResult.patientId}."
+        }
+
+        val newIsinPatientId = when (patientValidationResult.status) {
+            PatientValidationResult.PATIENT_FOUND ->
+                patientValidationResult.patientId
+            else -> {
+                null
+            }
+        }
+
+        if (newIsinPatientId != null) {
+            logger.debug { "Updating ISIN id of patient ${patient.id} to $newIsinPatientId"}
+            patientRepository.updatePatientChangeSet(id = patient.id, isinId = newIsinPatientId.trim())
+        } else {
+            logger.debug { "NOT updating ISIN id of patient ${patient.id}"}
+        }
+        return newIsinPatientId
+    }
+
+    private suspend fun retryPatientContactInfoExport(patient: PatientDtoOut): Boolean {
+        if (patient.dataCorrect == null) {
+            throw AssertionError { "Data correctness cannot be null." }
+        }
+
+        val wasExported = isinService.tryExportPatientContactInfo(patient, notes= patient.dataCorrect.notes)
+
+        if (wasExported) {
+            logger.debug { "Updating exported to ISIN of correctness ${patient.dataCorrect.id} (patient ${patient.id})"}
+            dataCorrectnessService.exportedToIsin(patient.dataCorrect.id)
+        } else {
+            logger.debug { "NOT updating exported to ISIN of correctness ${patient.dataCorrect.id} (patient ${patient.id})"}
+        }
+        return wasExported
+    }
+
+    private suspend fun retryPatientVaccinationCreation(patient: PatientDtoOut): Boolean {
+        if (patient.vaccinated == null) {
+            throw AssertionError { "Vaccination cannot be null." }
+        }
+
+        val vaccination = vaccinationService.get(patient.vaccinated.id)
+
+        // Try to export vaccination to ISIN
+        val wasExported = isinService.tryCreateVaccinationAndDose(
+            vaccination.toPatientVaccinationDetailDto(),
+            patient = patient
+        )
+
+        if (wasExported) {
+            logger.debug { "Updating exported to ISIN of vaccination ${patient.vaccinated.id} (patient ${patient.id})"}
+            vaccinationService.exportedToIsin(patient.vaccinated.id)
+        } else {
+            logger.debug { "NOT updating exported to ISIN of vaccination ${patient.vaccinated.id} (patient ${patient.id})"}
+        }
+        return wasExported
+    }
+}

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/service/IsinRetryService.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/service/IsinRetryService.kt
@@ -36,10 +36,10 @@ class IsinRetryService(
             offset = isinJobDto.patientsOffset.toLong()
         )
 
-        logger.debug("${patients.count()} patients will be processed.")
+        logger.info("${patients.count()} patients will be processed.")
 
         for (patient in patients) {
-            logger.debug("Checking ISIN id of patient ${patient.id}")
+            logger.info("Checking ISIN id of patient ${patient.id}")
 
             // 1. If patient has personal number but ISIN id is not set -> try ISIN validation
             val updatedPatient = if (!patient.isinId.isNullOrBlank()) {
@@ -69,7 +69,7 @@ class IsinRetryService(
             if (updatedPatient.isinId.isNullOrBlank()) continue
 
             // 2. If data are correct but not exported to ISIN -> try export to isin
-            logger.debug("Checking correctness exported to ISIN of patient ${updatedPatient.id}")
+            logger.info("Checking correctness exported to ISIN of patient ${updatedPatient.id}")
             if (
                 isinJobDto.exportPatientsInfo &&
                 updatedPatient.dataCorrect != null &&
@@ -90,7 +90,7 @@ class IsinRetryService(
 
             // 3. If vaccinated but vaccination is not exported to ISIN -> try export vaccination to ISIN
             if (isinJobDto.exportVaccinations && updatedPatient.vaccinated != null && updatedPatient.vaccinated.exportedToIsinOn == null) {
-                logger.debug("Retrying to create vaccination of patient ${updatedPatient.id} in ISIN")
+                logger.info("Retrying to create vaccination of patient ${updatedPatient.id} in ISIN")
                 val wasCreated = retryPatientVaccinationCreation(updatedPatient)
 
                 logger.info("Patient ${patient.id} vaccination was created in ISIN with result: ${wasCreated}")

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/service/IsinValidationService.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/service/IsinValidationService.kt
@@ -2,7 +2,6 @@ package blue.mild.covid.vaxx.service
 
 import blue.mild.covid.vaxx.dto.internal.IsinValidationResultDto
 import blue.mild.covid.vaxx.dto.internal.PatientValidationResult
-import blue.mild.covid.vaxx.dto.request.PatientRegistrationDtoIn
 import mu.KLogging
 
 
@@ -21,12 +20,11 @@ class IsinValidationService(
 
     private companion object : KLogging()
 
-    override suspend fun validatePatient(registrationDto: PatientRegistrationDtoIn): IsinValidationResultDto {
-        val firstName = registrationDto.firstName
-        val lastName = registrationDto.lastName
-        val personalNumber = registrationDto.personalNumber
-            ?: throw IllegalArgumentException("Personal number cannot be null for ISIN validation")
-
+    override suspend fun validatePatient(
+        firstName: String,
+        lastName: String,
+        personalNumber: String
+    ): IsinValidationResultDto {
         val result = runCatching {
             isinService.getPatientByParameters(
                 firstName = firstName,

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/service/PatientService.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/service/PatientService.kt
@@ -30,7 +30,7 @@ class PatientService(
      * Returns patient with given ID.
      */
     suspend fun getPatientById(patientId: EntityId): PatientDtoOut =
-        patientRepository.getAndMapPatientsBy( { Patients.id eq patientId } )
+        patientRepository.getAndMapPatientsBy { Patients.id eq patientId }
             .singleOrNull()
             ?.withSortedAnswers() ?: throw entityNotFound<Patients>(Patients::id, patientId)
 
@@ -38,18 +38,18 @@ class PatientService(
      * Returns single patient with given personal number or throws exception.
      */
     suspend fun getPatientByPersonalNumber(patientPersonalNumber: String): PatientDtoOut =
-        patientRepository.getAndMapPatientsBy( {
+        patientRepository.getAndMapPatientsBy {
             Patients.personalNumber eq patientPersonalNumber.normalizePersonalNumber()
-        }).singleOrNull()?.withSortedAnswers()
+        }.singleOrNull()?.withSortedAnswers()
             ?: throw entityNotFound<Patients>(Patients::personalNumber, patientPersonalNumber)
 
     /**
      * Returns single patient with given insurance number or throws exception.
      */
     suspend fun getPatientByInsuranceNumber(patientInsuranceNumber: String): PatientDtoOut =
-        patientRepository.getAndMapPatientsBy( {
+        patientRepository.getAndMapPatientsBy{
             Patients.insuranceNumber eq patientInsuranceNumber.trim()
-        }).singleOrNull()?.withSortedAnswers()
+        }.singleOrNull()?.withSortedAnswers()
             ?: throw entityNotFound<Patients>(Patients::insuranceNumber, patientInsuranceNumber)
 
     /**
@@ -63,22 +63,21 @@ class PatientService(
         offset: Long = 0
     ): List<PatientDtoOut> =
         patientRepository.getAndMapPatientsBy(
-            {
-                Op.TRUE
-                    .andWithIfNotEmpty(email?.removeAllWhitespaces()?.lowercase(Locale.getDefault()), Patients.email)
-                    .andWithIfNotEmpty(phoneNumber?.removeAllWhitespaces(), Patients.phoneNumber)
-                    .let { query ->
-                        vaccinated?.let {
-                            query.and(
-                                if (vaccinated) Patients.vaccination.isNotNull()
-                                else Patients.vaccination.isNull()
-                            )
-                        } ?: query
-                    }
-            },
             n = n,
             offset = offset
-        ).sorted()
+        ){
+            Op.TRUE
+                .andWithIfNotEmpty(email?.removeAllWhitespaces()?.lowercase(Locale.getDefault()), Patients.email)
+                .andWithIfNotEmpty(phoneNumber?.removeAllWhitespaces(), Patients.phoneNumber)
+                .let { query ->
+                    vaccinated?.let {
+                        query.and(
+                            if (vaccinated) Patients.vaccination.isNotNull()
+                            else Patients.vaccination.isNull()
+                        )
+                    } ?: query
+                }
+        }.sorted()
 
     /**
      * Updates patient with given change set.

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/service/PatientService.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/service/PatientService.kt
@@ -30,7 +30,7 @@ class PatientService(
      * Returns patient with given ID.
      */
     suspend fun getPatientById(patientId: EntityId): PatientDtoOut =
-        patientRepository.getAndMapPatientsBy { Patients.id eq patientId }
+        patientRepository.getAndMapPatientsBy( { Patients.id eq patientId } )
             .singleOrNull()
             ?.withSortedAnswers() ?: throw entityNotFound<Patients>(Patients::id, patientId)
 
@@ -38,18 +38,18 @@ class PatientService(
      * Returns single patient with given personal number or throws exception.
      */
     suspend fun getPatientByPersonalNumber(patientPersonalNumber: String): PatientDtoOut =
-        patientRepository.getAndMapPatientsBy {
+        patientRepository.getAndMapPatientsBy( {
             Patients.personalNumber eq patientPersonalNumber.normalizePersonalNumber()
-        }.singleOrNull()?.withSortedAnswers()
+        }).singleOrNull()?.withSortedAnswers()
             ?: throw entityNotFound<Patients>(Patients::personalNumber, patientPersonalNumber)
 
     /**
      * Returns single patient with given insurance number or throws exception.
      */
     suspend fun getPatientByInsuranceNumber(patientInsuranceNumber: String): PatientDtoOut =
-        patientRepository.getAndMapPatientsBy {
+        patientRepository.getAndMapPatientsBy( {
             Patients.insuranceNumber eq patientInsuranceNumber.trim()
-        }.singleOrNull()?.withSortedAnswers()
+        }).singleOrNull()?.withSortedAnswers()
             ?: throw entityNotFound<Patients>(Patients::insuranceNumber, patientInsuranceNumber)
 
     /**
@@ -58,21 +58,27 @@ class PatientService(
     suspend fun getPatientsByConjunctionOf(
         email: String? = null,
         phoneNumber: String? = null,
-        vaccinated: Boolean? = null
+        vaccinated: Boolean? = null,
+        n: Int? = null,
+        offset: Long = 0
     ): List<PatientDtoOut> =
-        patientRepository.getAndMapPatientsBy {
-            Op.TRUE
-                .andWithIfNotEmpty(email?.removeAllWhitespaces()?.lowercase(Locale.getDefault()), Patients.email)
-                .andWithIfNotEmpty(phoneNumber?.removeAllWhitespaces(), Patients.phoneNumber)
-                .let { query ->
-                    vaccinated?.let {
-                        query.and(
-                            if (vaccinated) Patients.vaccination.isNotNull()
-                            else Patients.vaccination.isNull()
-                        )
-                    } ?: query
-                }
-        }.sorted()
+        patientRepository.getAndMapPatientsBy(
+            {
+                Op.TRUE
+                    .andWithIfNotEmpty(email?.removeAllWhitespaces()?.lowercase(Locale.getDefault()), Patients.email)
+                    .andWithIfNotEmpty(phoneNumber?.removeAllWhitespaces(), Patients.phoneNumber)
+                    .let { query ->
+                        vaccinated?.let {
+                            query.and(
+                                if (vaccinated) Patients.vaccination.isNotNull()
+                                else Patients.vaccination.isNull()
+                            )
+                        } ?: query
+                    }
+            },
+            n = n,
+            offset = offset
+        ).sorted()
 
     /**
      * Updates patient with given change set.

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/service/PatientValidationService.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/service/PatientValidationService.kt
@@ -1,11 +1,10 @@
 package blue.mild.covid.vaxx.service
 
 import blue.mild.covid.vaxx.dto.internal.PatientValidationResultDto
-import blue.mild.covid.vaxx.dto.request.PatientRegistrationDtoIn
 
 fun interface PatientValidationService {
     /**
      * Validates patient against medical system service.
      */
-    suspend fun validatePatient(registrationDto: PatientRegistrationDtoIn): PatientValidationResultDto
+    suspend fun validatePatient(firstName: String, lastName: String, personalNumber: String): PatientValidationResultDto
 }

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/service/dummy/DummyIsinService.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/service/dummy/DummyIsinService.kt
@@ -16,7 +16,7 @@ class DummyIsinService : IsinServiceInterface {
         personalNumber: String
     ): IsinGetPatientByParametersResultDto {
         logger.warn { "NOT GETTING patient ${firstName}/${lastName}/${personalNumber} from ISIN. This should not be in the production." }
-        return IsinGetPatientByParametersResultDto("Chyba", null, null)
+        return IsinGetPatientByParametersResultDto("PouzitiDummyISIN", null, null)
     }
 
     override suspend fun tryExportPatientContactInfo(

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/service/dummy/DummyIsinService.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/service/dummy/DummyIsinService.kt
@@ -16,7 +16,7 @@ class DummyIsinService : IsinServiceInterface {
         personalNumber: String
     ): IsinGetPatientByParametersResultDto {
         logger.warn { "NOT GETTING patient ${firstName}/${lastName}/${personalNumber} from ISIN. This should not be in the production." }
-        return IsinGetPatientByParametersResultDto("PacientNebylNalezen", null, null)
+        return IsinGetPatientByParametersResultDto("Chyba", null, null)
     }
 
     override suspend fun tryExportPatientContactInfo(

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/service/dummy/DummyPatientValidationService.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/service/dummy/DummyPatientValidationService.kt
@@ -3,15 +3,18 @@ package blue.mild.covid.vaxx.service.dummy
 import blue.mild.covid.vaxx.dto.internal.IsinValidationResultDto
 import blue.mild.covid.vaxx.dto.internal.PatientValidationResult
 import blue.mild.covid.vaxx.dto.internal.PatientValidationResultDto
-import blue.mild.covid.vaxx.dto.request.PatientRegistrationDtoIn
 import blue.mild.covid.vaxx.service.PatientValidationService
 import mu.KLogging
 
 class DummyPatientValidationService : PatientValidationService {
     private companion object : KLogging()
 
-    override suspend fun validatePatient(registrationDto: PatientRegistrationDtoIn): PatientValidationResultDto {
-        logger.warn { "NOT VERIFYING patient ${registrationDto.personalNumber}. This should not be in the production." }
+    override suspend fun validatePatient(
+        firstName: String,
+        lastName: String,
+        personalNumber: String
+    ): PatientValidationResultDto {
+        logger.warn { "NOT VERIFYING patient ${personalNumber}. This should not be in the production." }
         return IsinValidationResultDto(PatientValidationResult.WAS_NOT_VERIFIED)
     }
 }

--- a/backend/src/main/kotlin/blue/mild/covid/vaxx/setup/DependencyInjection.kt
+++ b/backend/src/main/kotlin/blue/mild/covid/vaxx/setup/DependencyInjection.kt
@@ -14,6 +14,7 @@ import blue.mild.covid.vaxx.extensions.createLogger
 import blue.mild.covid.vaxx.security.ddos.CaptchaVerificationService
 import blue.mild.covid.vaxx.security.ddos.RequestVerificationService
 import blue.mild.covid.vaxx.service.DataCorrectnessService
+import blue.mild.covid.vaxx.service.IsinRetryService
 import blue.mild.covid.vaxx.service.IsinServiceInterface
 import blue.mild.covid.vaxx.service.IsinService
 import blue.mild.covid.vaxx.service.IsinValidationService
@@ -103,6 +104,7 @@ fun DI.MainBuilder.registerClasses() {
     bind<DataCorrectnessService>() with singleton { DataCorrectnessService(instance(), instance()) }
     bind<MailJetEmailService>() with singleton { MailJetEmailService(instance(), instance(), instance(), instance()) }
     bind<SystemStatisticsService>() with singleton { SystemStatisticsService() }
+    bind<IsinRetryService>() with singleton { IsinRetryService(instance(), instance(), instance(), instance(), instance(), instance()) }
 
     bind<MailjetClient>() with singleton {
         val mailJetConfig = instance<MailJetConfigurationDto>()

--- a/backend/src/test/kotlin/blue/mild/covid/vaxx/requests/http-client.env.json
+++ b/backend/src/test/kotlin/blue/mild/covid/vaxx/requests/http-client.env.json
@@ -1,6 +1,8 @@
 {
   "local": {
-    "url": "http://localhost:8080/api"
+    "url": "http://localhost:8080/api",
+    "email": "vaxx@mild.blue",
+    "password": "bluemild"
   },
   "staging": {
     "url": "https://covid-vaxx.stg.mild.blue/api",

--- a/backend/src/test/kotlin/blue/mild/covid/vaxx/requests/test-staging.http
+++ b/backend/src/test/kotlin/blue/mild/covid/vaxx/requests/test-staging.http
@@ -138,3 +138,16 @@ Authorization: Bearer {{auth_token}}
 }
 
 ###
+
+POST {{url}}/admin/run-isin-job
+Content-Type: application/json
+Authorization: Bearer {{auth_token}}
+
+{
+  "exportPatientsInfo": true,
+  "exportVaccinations": true,
+  "validatePatients": true,
+
+  "patientsCount": null,
+  "patientsOffset": 0
+}

--- a/backend/src/test/kotlin/blue/mild/covid/vaxx/requests/test-staging.http
+++ b/backend/src/test/kotlin/blue/mild/covid/vaxx/requests/test-staging.http
@@ -3,7 +3,7 @@ Content-Type: application/json
 
 {
   "credentials": {
-    "email": "{{user}}",
+    "email": "{{email}}",
     "password": "{{password}}"
   },
   "vaccineSerialNumber": "test",

--- a/backend/src/test/kotlin/blue/mild/covid/vaxx/routes/PatientRoutesTest.kt
+++ b/backend/src/test/kotlin/blue/mild/covid/vaxx/routes/PatientRoutesTest.kt
@@ -64,7 +64,7 @@ class PatientRoutesTest : ServerTestBase() {
         bind<PatientValidationService>() with singleton {
             val service = mockk<PatientValidationService>()
             coEvery {
-                service.validatePatient(any())
+                service.validatePatient(any(), any(), any())
             } returns IsinValidationResultDto(PatientValidationResult.PATIENT_FOUND, "10")
 
             service
@@ -309,7 +309,11 @@ class PatientRoutesTest : ServerTestBase() {
         println(validationService.hashCode())
 
         coEvery {
-            validationService.validatePatient(validRegistration)
+            validationService.validatePatient(
+                validRegistration.firstName,
+                validRegistration.lastName,
+                validRegistration.personalNumber ?: ""
+            )
         } returns IsinValidationResultDto(PatientValidationResult.PATIENT_NOT_FOUND)
 
         handleRequest(HttpMethod.Post, patientRoute) {

--- a/frontend/src/app/generated/api/default.service.ts
+++ b/frontend/src/app/generated/api/default.service.ts
@@ -24,6 +24,8 @@ import {
   DataCorrectnessDtoIn,
   EntityIdDtoOut,
   InsuranceCompanyDetailsDtoOut,
+  IsinJobDtoIn,
+  IsinJobDtoOut,
   LocationDtoIn,
   LocationDtoOut,
   LoginDtoIn,
@@ -892,6 +894,65 @@ export class DefaultService {
 
     return this.httpClient.post<UserRegisteredDtoOut>(`${this.configuration.basePath}/api/admin/register`,
       userRegistrationDtoIn,
+      {
+        responseType: <any>responseType,
+        withCredentials: this.configuration.withCredentials,
+        headers: headers,
+        observe: observe,
+        reportProgress: reportProgress
+      }
+    );
+  }
+
+  /**
+   * Checks patients where ISIN was failed and run isin client again.
+   * @param isinJobDtoIn
+   * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+   * @param reportProgress flag to report request and response progress.
+   */
+  public apiAdminRunIsinJobPost(isinJobDtoIn?: IsinJobDtoIn, observe?: 'body', reportProgress?: boolean, options?: { httpHeaderAccept?: 'application/json' }): Observable<IsinJobDtoOut>;
+  public apiAdminRunIsinJobPost(isinJobDtoIn?: IsinJobDtoIn, observe?: 'response', reportProgress?: boolean, options?: { httpHeaderAccept?: 'application/json' }): Observable<HttpResponse<IsinJobDtoOut>>;
+  public apiAdminRunIsinJobPost(isinJobDtoIn?: IsinJobDtoIn, observe?: 'events', reportProgress?: boolean, options?: { httpHeaderAccept?: 'application/json' }): Observable<HttpEvent<IsinJobDtoOut>>;
+  public apiAdminRunIsinJobPost(isinJobDtoIn?: IsinJobDtoIn, observe: any = 'body', reportProgress: boolean = false, options?: { httpHeaderAccept?: 'application/json' }): Observable<any> {
+
+    let headers = this.defaultHeaders;
+
+    let credential: string | undefined;
+    // authentication (jwtAuth) required
+    credential = this.configuration.lookupCredential('jwtAuth');
+    if (credential) {
+      headers = headers.set('Authorization', 'Bearer ' + credential);
+    }
+
+    let httpHeaderAcceptSelected: string | undefined = options && options.httpHeaderAccept;
+    if (httpHeaderAcceptSelected === undefined) {
+      // to determine the Accept header
+      const httpHeaderAccepts: string[] = [
+        'application/json'
+      ];
+      httpHeaderAcceptSelected = this.configuration.selectHeaderAccept(httpHeaderAccepts);
+    }
+    if (httpHeaderAcceptSelected !== undefined) {
+      headers = headers.set('Accept', httpHeaderAcceptSelected);
+    }
+
+
+    // to determine the Content-Type header
+    const consumes: string[] = [
+      'application/json'
+    ];
+    const httpContentTypeSelected: string | undefined = this.configuration.selectHeaderContentType(consumes);
+    if (httpContentTypeSelected !== undefined) {
+      headers = headers.set('Content-Type', httpContentTypeSelected);
+    }
+
+    let responseType: 'text' | 'json' = 'json';
+    if (httpHeaderAcceptSelected && httpHeaderAcceptSelected.startsWith('text')) {
+      responseType = 'text';
+    }
+
+    return this.httpClient.post<IsinJobDtoOut>(`${this.configuration.basePath}/api/admin/run-isin-job`,
+      isinJobDtoIn,
       {
         responseType: <any>responseType,
         withCredentials: this.configuration.withCredentials,

--- a/frontend/src/app/generated/model/dataCorrectnessConfirmationDtoOut.ts
+++ b/frontend/src/app/generated/model/dataCorrectnessConfirmationDtoOut.ts
@@ -13,6 +13,8 @@
 
 export interface DataCorrectnessConfirmationDtoOut {
   dataAreCorrect: boolean;
+  exportedToIsinOn?: string | null;
   id: string;
+  notes?: string | null;
 }
 

--- a/frontend/src/app/generated/model/isinJobDtoIn.ts
+++ b/frontend/src/app/generated/model/isinJobDtoIn.ts
@@ -11,10 +11,11 @@
  */
 
 
-export interface VaccinationDtoOut {
-  exportedToIsinOn?: string | null;
-  id: string;
-  notes?: string | null;
-  vaccinatedOn: string;
+export interface IsinJobDtoIn {
+  exportPatientsInfo: boolean;
+  exportVaccinations: boolean;
+  patientsCount?: number | null;
+  patientsOffset: number;
+  validatePatients: boolean;
 }
 

--- a/frontend/src/app/generated/model/isinJobDtoOut.ts
+++ b/frontend/src/app/generated/model/isinJobDtoOut.ts
@@ -11,10 +11,12 @@
  */
 
 
-export interface VaccinationDtoOut {
-  exportedToIsinOn?: string | null;
-  id: string;
-  notes?: string | null;
-  vaccinatedOn: string;
+export interface IsinJobDtoOut {
+  exportedPatientsInfoErrors: number;
+  exportedPatientsInfoSuccess: number;
+  exportedVaccinationsErrors: number;
+  exportedVaccinationsSuccess: number;
+  validatedPatientsErrors: number;
+  validatedPatientsSuccess: number;
 }
 

--- a/frontend/src/app/generated/model/models.ts
+++ b/frontend/src/app/generated/model/models.ts
@@ -9,6 +9,8 @@ export * from './dataCorrectnessConfirmationDtoOut';
 export * from './dataCorrectnessDtoIn';
 export * from './entityIdDtoOut';
 export * from './insuranceCompanyDetailsDtoOut';
+export * from './isinJobDtoIn';
+export * from './isinJobDtoOut';
 export * from './locationDtoIn';
 export * from './locationDtoOut';
 export * from './loginDtoIn';

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Registrační formulář na očkování Covid-19</title>
+  <title>Registrační formulář na očkování proti Covid-19</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Covid-19 vaccine questionnaire</title>
+  <title>Registrační formulář na očkování Covid-19</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
Api prochází zadaný počet pacientů v db. Pokud nějaký pacient není validovaný (nemá ISIN id), zkusí ho to znovu v isin validovat. Podobně pokud informace o pacientovi nebyly updatované v ISIN, zkusí je to updatovat znovu a případně podobně nahraje do ISIN i vakcinaci.

Několik poznámek:
- api není asynchronní
- pokud nejsou přenastavené patientsCount a patientsOffset, projde to všechny pacienty v db, pokud se počet pacientů omezí, nechová se to jak bychom chtěli. Zatím se mi nepodařilo přijít na to proč
- zatím to nehandluje případy, kdy už je vytvořená vakcinace a chceme k ní vytvořit jen dávku

Closes https://github.com/mild-blue/covid-vaxx/issues/295